### PR TITLE
Add Docker support with automated container publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: kapetan-io/querator
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Get version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# Build stage
+FROM golang:1.23.1-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git ca-certificates
+
+# Set working directory
+WORKDIR /app
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+ARG VERSION
+
+# Build the binary
+RUN go build -ldflags "-w -s -X main.Version=$VERSION" -o querator ./cmd/querator
+
+# Final stage
+FROM alpine:latest
+
+# Install runtime dependencies
+RUN apk --no-cache add ca-certificates tzdata
+
+# Create app user
+RUN addgroup -g 1001 -S querator && \
+    adduser -u 1001 -S querator -G querator
+
+# Create directories for data and config
+RUN mkdir -p /data /config && \
+    chown -R querator:querator /data /config
+
+# Copy binary from builder
+COPY --from=builder /app/querator /usr/local/bin/querator
+COPY --from=builder /app/example.yaml /config/default.yaml
+
+# Set permissions
+RUN chmod +x /usr/local/bin/querator
+
+# Switch to non-root user
+USER querator
+
+# Set working directory
+WORKDIR /data
+
+# Expose port (default querator port)
+EXPOSE 9090
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:9090/health || exit 1
+
+# Default command - use default config if no config mounted
+CMD ["sh", "-c", "if [ -f /config/querator.yaml ]; then querator -config /config/querator.yaml; else querator -config /config/default.yaml; fi"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL := build
 LINT = $(GOPATH)/bin/golangci-lint
 LINT_VERSION = v1.64.6
+VERSION=$(shell cat version)
 
 .PHONY: proto
 proto: ## Build protos
@@ -37,4 +38,9 @@ ci: tidy lint test
 .PHONY: vet
 vet:
 	go vet ./...
+
+.PHONY: docker
+docker: ## Build Docker image
+	docker build --build-arg VERSION=$(VERSION) -t ghcr.io/kapetan-io/querator:$(VERSION) .
+	docker tag ghcr.io/kapetan-io/querator:$(VERSION) ghcr.io/kapetan-io/querator:latest
 

--- a/cmd/querator/main.go
+++ b/cmd/querator/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -14,6 +15,8 @@ import (
 	"github.com/kapetan-io/querator/daemon"
 	"gopkg.in/yaml.v3"
 )
+
+var Version = "dev-build"
 
 type FlagParams struct {
 	ConfigFile string
@@ -49,6 +52,7 @@ func Start(ctx context.Context, args []string, w io.Writer) error {
 		return fmt.Errorf("while applying config file: %w", err)
 	}
 
+	conf.Log.Info(fmt.Sprintf("Querator %s (%s/%s)", Version, runtime.GOARCH, runtime.GOOS))
 	d, err := daemon.NewDaemon(ctx, conf)
 	if err != nil {
 		return fmt.Errorf("while creating daemon: %w", err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+  querator:
+    image: ghcr.io/kapetan-io/querator:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      # Mount local data directory for persistent storage
+      - ./:/data
+    environment:
+      - TZ=UTC
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9090/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/version
+++ b/version
@@ -1,0 +1,1 @@
+dev-build


### PR DESCRIPTION
### Purpose
Add Docker containerization support to enable standardized deployment and automated container publishing to GitHub Container Registry on releases.

### Implementation
- Multi-stage Dockerfile with Go 1.23.1 build environment and Alpine runtime
- Docker Compose configuration for local development with volume mounting
- GitHub Actions workflow that builds multi-platform images (amd64/arm64) on release
- Version handling integration with existing build system
- Makefile targets for Docker operations