### PR TITLE
Change complete command to use --partition flag instead of positional argument

### DIFF
--- a/cmd/querator/cli_test.go
+++ b/cmd/querator/cli_test.go
@@ -94,10 +94,11 @@ func TestCompleteCommand(t *testing.T) {
 	testFlags := main.FlagParams{
 		CompleteTimeout: "30s",
 		Endpoint:        ms.URL(),
+		Partition:       0,
 	}
 
 	_, stderr, err := captureOutput(func() error {
-		return main.RunComplete(testFlags, "test-queue", 0, []string{"item1", "item2"})
+		return main.RunComplete(testFlags, "test-queue", testFlags.Partition, []string{"item1", "item2"})
 	})
 
 	require.NoError(t, err)
@@ -388,10 +389,11 @@ func TestCompleteCommandWithFile(t *testing.T) {
 		File:            tempFile.Name(),
 		CompleteTimeout: "30s",
 		Endpoint:        ms.URL(),
+		Partition:       0,
 	}
 
 	_, stderr, err := captureOutput(func() error {
-		return main.RunComplete(testFlags, "test-queue", 0, []string{})
+		return main.RunComplete(testFlags, "test-queue", testFlags.Partition, []string{})
 	})
 
 	require.NoError(t, err)

--- a/cmd/querator/main.go
+++ b/cmd/querator/main.go
@@ -36,6 +36,7 @@ type FlagParams struct {
 	// Complete Flags
 	File            string
 	CompleteTimeout string
+	Partition       int32
 
 	// Create Flags
 	LeaseTimeoutCreate string


### PR DESCRIPTION
### Purpose
Improve CLI usability by changing the complete command to accept partition as a named flag instead of a positional argument, making the interface more explicit and consistent with common CLI patterns.

### Implementation
- Added Partition field to FlagParams structure for complete command configuration
- Updated complete command to accept --partition/-p flag instead of positional argument
- Added short alias -p for convenient usage
- Marked partition flag as required to maintain existing validation
- Updated command usage from `complete <queue> <partition> <id>...` to `complete <queue> <id>...`
- Updated tests to use partition flag in test parameters instead of hardcoded values
- Removed unused strconv import since partition parsing is now handled by cobra flags

Command format change:
**Before:** `querator complete my-queue 0 item-id`
**After:** `querator complete my-queue --partition=0 item-id` or `querator complete my-queue -p 0 item-id`