### PR TITLE
Add InMemoryListener integration for daemon testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage.html
 .env
 docs/notes
 docs/plans
+testdata/

--- a/client.go
+++ b/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kapetan-io/tackle/clock"
 	"github.com/kapetan-io/tackle/set"
 	"google.golang.org/protobuf/proto"
+	"net"
 	"net/http"
 )
 
@@ -394,6 +395,24 @@ func WithTLS(tls *tls.Config, address string) ClientConfig {
 				MaxConnsPerHost:     2_000,
 				MaxIdleConns:        2_000,
 				MaxIdleConnsPerHost: 2_000,
+				IdleConnTimeout:     60 * clock.Second,
+			},
+		},
+	}
+}
+
+// WithConn returns ClientConfig suitable for use with a custom net.Conn connection
+func WithConn(conn net.Conn) ClientConfig {
+	return ClientConfig{
+		Endpoint: "http://memory",
+		Client: &http.Client{
+			Transport: &http.Transport{
+				Dial: func(network, addr string) (net.Conn, error) {
+					return conn, nil
+				},
+				MaxConnsPerHost:     1,
+				MaxIdleConns:        1,
+				MaxIdleConnsPerHost: 1,
 				IdleConnTimeout:     60 * clock.Second,
 			},
 		},

--- a/common_test.go
+++ b/common_test.go
@@ -59,7 +59,6 @@ func TestMain(m *testing.M) {
 	}
 
 	goleak.VerifyTestMain(m)
-	//os.Exit(m.Run())
 }
 
 // ---------------------------------------------------------------------

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -25,6 +25,12 @@ type Config struct {
 	// single `/queue.produce` request including the size of all fields in the marshalled protobuf.
 	// The default size is 1MB.
 	MaxProducePayloadSize int64
+
+	// InMemoryListener is true if daemon should ignore ListenAddress and use net.Pipe to listen for
+	// and handle new connections. When true, calls to Daemon.Client() and Daemon.MustClient() will return
+	// a new instance of the client bound to the client portion of a net.Pipe. This is useful for testing
+	// querator where access to the loop back is not allowed, or when using testing/synctest
+	InMemoryListener bool
 }
 
 func (c *Config) ClientTLS() *tls.Config {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -80,7 +80,11 @@ func (d *Daemon) Start(ctx context.Context) error {
 	), d.conf.MaxProducePayloadSize, d.conf.Log)
 	registry.MustRegister(handler)
 
-	if d.conf.ServerTLS() != nil {
+	if d.conf.InMemoryListener {
+		if err := d.spawnInMemory(ctx, handler); err != nil {
+			return err
+		}
+	} else if d.conf.ServerTLS() != nil {
 		if err := d.spawnHTTPS(ctx, handler); err != nil {
 			return err
 		}
@@ -114,12 +118,34 @@ func (d *Daemon) Service() *querator.Service {
 func (d *Daemon) MustClient() *querator.Client {
 	c, err := d.Client()
 	if err != nil {
-		panic(fmt.Sprintf("[%s] failed to init daemon client - '%d'", d.conf.InstanceID, err))
+		panic(fmt.Sprintf("[%s] failed to init daemon client - '%s'", d.conf.InstanceID, err))
 	}
 	return c
 }
 
 func (d *Daemon) Client() (*querator.Client, error) {
+	if d.conf.InMemoryListener {
+		// Create a new net.Pipe for each client connection
+		clientConn, serverConn := net.Pipe()
+
+		// Serve the server side of the pipe through the InMemoryListener
+		if inMemListener, ok := d.Listener.(*InMemoryListener); ok {
+			if err := inMemListener.ServeConn(serverConn); err != nil {
+				clientConn.Close()
+				serverConn.Close()
+				return nil, fmt.Errorf("failed to serve connection: %w", err)
+			}
+		} else {
+			clientConn.Close()
+			serverConn.Close()
+			return nil, fmt.Errorf("InMemoryListener is enabled but listener is not of type *InMemoryListener")
+		}
+
+		// Create a new client using the client side of the pipe
+		return querator.NewClient(querator.WithConn(clientConn))
+	}
+
+	// Original logic for non-InMemoryListener clients
 	var err error
 	if d.client != nil {
 		return d.client, nil
@@ -198,6 +224,30 @@ func (d *Daemon) spawnHTTP(ctx context.Context, h http.Handler) error {
 	}
 
 	d.conf.Log.Info("HTTP Server Started", "address", d.Listener.Addr().String())
+	d.servers = append(d.servers, srv)
+	return nil
+}
+
+func (d *Daemon) spawnInMemory(ctx context.Context, h http.Handler) error {
+	srv := &http.Server{
+		ErrorLog: slog.NewLogLogger(d.conf.Log.Handler(), slog.LevelError),
+		Handler:  h,
+	}
+
+	d.Listener = NewInMemoryListener()
+	srv.Addr = d.Listener.Addr().String()
+
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		if err := srv.Serve(d.Listener); err != nil {
+			if !errors.Is(err, http.ErrServerClosed) {
+				d.conf.Log.Error("while starting InMemory server", "error", err)
+			}
+		}
+	}()
+
+	d.conf.Log.Info("InMemory Server Started", "address", d.Listener.Addr().String())
 	d.servers = append(d.servers, srv)
 	return nil
 }

--- a/daemon/listener.go
+++ b/daemon/listener.go
@@ -1,0 +1,56 @@
+package daemon
+
+import (
+	"io"
+	"net"
+	"sync/atomic"
+)
+
+// InMemoryListener is intended to be used with testing/synctest
+type InMemoryListener struct {
+	closed   chan struct{}
+	connCh   chan net.Conn
+	isClosed atomic.Bool
+}
+
+func NewInMemoryListener() *InMemoryListener {
+	return &InMemoryListener{
+		connCh: make(chan net.Conn),
+		closed: make(chan struct{}),
+	}
+}
+
+func (l *InMemoryListener) ServeConn(conn net.Conn) error {
+	if l.isClosed.Load() {
+		return net.ErrClosed
+	}
+
+	l.connCh <- conn
+	return nil
+}
+
+func (l *InMemoryListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.connCh:
+		return c, nil
+	case <-l.closed:
+		return nil, io.EOF
+	}
+}
+
+func (l *InMemoryListener) Close() error {
+	if !l.isClosed.CompareAndSwap(false, true) {
+		return nil
+	}
+	close(l.closed)
+	return nil
+}
+
+func (l *InMemoryListener) Addr() net.Addr {
+	return memAddr("memory-listener")
+}
+
+type memAddr string
+
+func (a memAddr) Network() string { return string(a) }
+func (a memAddr) String() string  { return string(a) }

--- a/daemon/listener_test.go
+++ b/daemon/listener_test.go
@@ -1,0 +1,115 @@
+package daemon_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/kapetan-io/querator/daemon"
+	pb "github.com/kapetan-io/querator/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestInMemoryListener(t *testing.T) {
+	listener := daemon.NewInMemoryListener()
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
+		}),
+	}
+	go server.Serve(listener)
+	defer server.Close()
+
+	clientCount := 3
+	var wg sync.WaitGroup
+	for i := 0; i < clientCount; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			// Each client gets its own net.Pipe
+			serverConn, clientConn := net.Pipe()
+			listener.ServeConn(serverConn)
+
+			// Custom DialContext returns the clientConn for this request
+			dialOnce := sync.Once{}
+
+			client := &http.Client{
+				Transport: &http.Transport{
+					DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+						var c net.Conn
+						dialOnce.Do(func() { c = clientConn })
+						return c, nil
+					},
+				},
+				Timeout: 2 * time.Second,
+			}
+
+			url := fmt.Sprintf("http://inmemory/client%d", id)
+			resp, err := client.Get(url)
+			if err != nil {
+				t.Errorf("client %d error: %v", id, err)
+				return
+			}
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(resp.Body)
+			expected := fmt.Sprintf("Hello, client%d!", id)
+			if !strings.Contains(string(body), expected) {
+				t.Errorf("client %d got unexpected body: %q", id, body)
+			}
+		}(i)
+	}
+	wg.Wait()
+	listener.Close()
+}
+
+func TestDaemonInMemoryListener(t *testing.T) {
+	ctx := context.Background()
+
+	// Create daemon with InMemoryListener enabled
+	d, err := daemon.NewDaemon(ctx, daemon.Config{
+		InMemoryListener: true,
+	})
+	require.NoError(t, err)
+	defer d.Shutdown(ctx)
+
+	// Get a client - should create a new net.Pipe connection
+	{
+		client, err := d.Client()
+		require.NoError(t, err)
+
+		// Test QueuesList to verify the connection works
+		var resp pb.QueuesListResponse
+		err = client.QueuesList(ctx, &resp, nil)
+		require.NoError(t, err)
+
+		// Verify we got an empty list
+		assert.Nil(t, resp.Items)
+
+		// Should work a second time also
+		err = client.QueuesList(ctx, &resp, nil)
+		require.NoError(t, err)
+
+		// Verify we got an empty list
+		assert.Nil(t, resp.Items)
+	}
+
+	// Test getting multiple clients - each should work independently
+	{
+		client, err := d.Client()
+		require.NoError(t, err)
+
+		// Test QueuesList to verify the connection works
+		var resp pb.QueuesListResponse
+		err = client.QueuesList(ctx, &resp, nil)
+		require.NoError(t, err)
+
+		// Verify we got an empty list
+		assert.Nil(t, resp.Items)
+	}
+}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,185 @@
+package querator_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	que "github.com/kapetan-io/querator"
+	"github.com/kapetan-io/querator/daemon"
+	"github.com/kapetan-io/querator/internal/store"
+	pb "github.com/kapetan-io/querator/proto"
+	"github.com/kapetan-io/tackle/random"
+	"github.com/kapetan-io/tackle/set"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// FuzzQueueInvariant tests the core queue property: all produced items must be
+// accounted for through their lifecycle (produced -> leased -> completed),
+// and completing all items should result in an empty queue.
+func FuzzQueueInvariant(f *testing.F) {
+	// Seed corpus with realistic item data
+	f.Add(10, 3, []byte("test data"), "json", "text/plain", "ref-12345")
+	f.Add(1, 1, []byte("\x00\x01\x02\x03\x04"), "binary", "application/octet-stream", "binary-ref")
+	f.Add(50, 10, []byte("larger payload with special chars: \n\t\x00"), "protobuf",
+		"application/octet-stream", "ref-abc-xyz")
+	f.Add(100, 25, []byte(""), "", "", "")
+
+	f.Fuzz(func(t *testing.T, itemCount, batchSize int,
+		payload []byte, encoding, kind, reference string) {
+		// Ensure valid input for each field
+		if !utf8.ValidString(encoding) || !utf8.ValidString(kind) || !utf8.ValidString(reference) ||
+			itemCount < 1 || batchSize < 1 || len(payload) < 1 {
+			t.Skip()
+		}
+		d, c, ctx := newFuzzDaemon(t, que.ServiceConfig{
+			StorageConfig: setupMemoryStorage(store.Config{}),
+		})
+		defer d.Shutdown(t)
+
+		queueName := fmt.Sprintf("fuzz-%d-%s", itemCount, random.Alpha("", 10))
+		createQueueAndWait(t, ctx, c, &pb.QueueInfo{
+			QueueName:           queueName,
+			LeaseTimeout:        "30s",
+			ExpireTimeout:       "5m",
+			MaxAttempts:         3,
+			RequestedPartitions: 1,
+		})
+
+		items := make([]*pb.QueueProduceItem, 0, itemCount)
+		produced := make(map[string]struct{})
+
+		// Generate items with variations based on fuzz inputs
+		for i := 0; i < itemCount; i++ {
+			ref := fmt.Sprintf("%s-%d", reference, i)
+			produced[ref] = struct{}{}
+
+			items = append(items, &pb.QueueProduceItem{
+				Encoding:  encoding,
+				Bytes:     payload,
+				Kind:      kind,
+				Reference: ref,
+			})
+		}
+
+		// Ensure the total produce payload does not exceed querator limits
+		payload, err := proto.Marshal(&pb.QueueProduceRequest{
+			QueueName:      queueName,
+			Items:          items,
+			RequestTimeout: "5s",
+		})
+		require.NoError(t, err)
+		if len(payload) >= 1_000_000 {
+			t.Skip()
+		}
+
+		// Produce all items
+		err = c.QueueProduce(ctx, &pb.QueueProduceRequest{
+			QueueName:      queueName,
+			Items:          items,
+			RequestTimeout: "5s",
+		})
+		require.NoError(t, err)
+
+		// Verify all items are in storage
+		var list pb.StorageItemsListResponse
+		err = c.StorageItemsList(ctx, queueName, 0, &list, &que.ListOptions{Limit: itemCount + 10})
+		require.NoError(t, err)
+		assert.Equal(t, itemCount, len(list.Items))
+
+		// Lease all items in batches
+		leasedItems := make(map[string]*pb.QueueLeaseItem)
+		totalLeased := 0
+
+		for totalLeased < itemCount {
+			var lease pb.QueueLeaseResponse
+			err := c.QueueLease(ctx, &pb.QueueLeaseRequest{
+				ClientId:       fmt.Sprintf("client-%d", totalLeased),
+				RequestTimeout: "5s",
+				QueueName:      queueName,
+				BatchSize:      int32(batchSize),
+			}, &lease)
+			require.NoError(t, err, "Failed to lease items")
+
+			// Track leased items
+			for _, item := range lease.Items {
+				assert.NotContains(t, leasedItems, item.Reference, "Item %s was leased multiple times", item.Reference)
+				leasedItems[item.Reference] = item
+				totalLeased++
+
+				// Verify fields were preserved
+				assert.Contains(t, item.Encoding, encoding)
+				assert.Equal(t, kind, item.Kind)
+			}
+
+			// Break if no more items available
+			if len(lease.Items) == 0 {
+				break
+			}
+		}
+
+		// Verify we leased all produced items
+		assert.Equal(t, itemCount, totalLeased, "Should lease all produced items")
+		assert.Equal(t, len(produced), len(leasedItems), "All produced items should be leased")
+
+		// Verify all produced references were leased
+		for ref := range produced {
+			_, exists := leasedItems[ref]
+			assert.True(t, exists, "Produced item %s was not leased", ref)
+		}
+
+		// Complete all leased items
+		completedCount := 0
+		for _, item := range leasedItems {
+			err := c.QueueComplete(ctx, &pb.QueueCompleteRequest{
+				QueueName:      queueName,
+				RequestTimeout: "5s",
+				Ids:            []string{item.Id},
+			})
+			require.NoError(t, err)
+			completedCount++
+		}
+		assert.Equal(t, itemCount, completedCount)
+
+		// Verify queue is now empty
+		err = c.StorageItemsList(ctx, queueName, 0, &list, &que.ListOptions{Limit: 10})
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(list.Items),
+			"Queue should be empty after completing all items")
+
+		// Try to lease again - should get nothing
+		var finalLease pb.QueueLeaseResponse
+		err = c.QueueLease(ctx, &pb.QueueLeaseRequest{
+			BatchSize:      int32(batchSize),
+			ClientId:       "final-client",
+			QueueName:      queueName,
+			RequestTimeout: "100ms",
+		}, &finalLease)
+		require.ErrorContains(t, err, "no items are in the queue, try again")
+		assert.Equal(t, 0, len(finalLease.Items))
+
+		// Clean up
+		err = c.QueuesDelete(ctx, &pb.QueuesDeleteRequest{QueueName: queueName})
+		require.NoError(t, err)
+	})
+}
+
+func newFuzzDaemon(t *testing.T, conf que.ServiceConfig) (*testDaemon, *que.Client, context.Context) {
+	t.Helper()
+
+	set.Default(&conf.Log, log)
+	td := &testDaemon{}
+	var err error
+
+	td.ctx, td.cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	td.d, err = daemon.NewDaemon(td.ctx, daemon.Config{
+		ListenAddress: "localhost:0",
+		ServiceConfig: conf,
+	})
+	require.NoError(t, err)
+	return td, td.d.MustClient(), td.ctx
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kapetan-io/querator
 
-go 1.23.1
+go 1.24.4
 
 require (
 	github.com/dgraph-io/badger/v4 v4.3.0


### PR DESCRIPTION
### Purpose
Enable daemon testing in environments where loopback access is restricted or when using testing/synctest by integrating the InMemoryListener functionality directly into the daemon lifecycle.

### Implementation
- Integrate InMemoryListener into daemon when Config.InMemoryListener=true
- Modify Daemon.Client() to create net.Pipe connections for InMemoryListener
- Add querator.WithConn() function to support custom net.Conn connections
- Add comprehensive test validating InMemoryListener integration