### PR TITLE
Update tackle to v0.13.0 to fix frozen clock race condition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/duh-rpc/duh-go v0.9.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/kapetan-io/errors v0.4.0
-	github.com/kapetan-io/tackle v0.9.0
+	github.com/kapetan-io/tackle v0.13.0
 	github.com/prometheus/client_golang v1.19.1
 	github.com/segmentio/ksuid v1.0.4
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kapetan-io/errors v0.4.0 h1:yzt6sYlXHvKQfPkE+T5uDtHwAgY2pJpNuNsRG+8QSKo=
 github.com/kapetan-io/errors v0.4.0/go.mod h1:Rc59bpJaA+YHiAyTY702+SmiL+iRQgpZXjR8S6mzyOg=
-github.com/kapetan-io/tackle v0.9.0 h1:TZQykrQXpX1U6BtEMezWLEnZySTLnQUK/f5PDpGJWqw=
-github.com/kapetan-io/tackle v0.9.0/go.mod h1:E7MpdJUog4MvyKkWtQyX8UjFe5tL4SHQ44ZGk+zDBM8=
+github.com/kapetan-io/tackle v0.13.0 h1:kcQTbgZN+4T89ktqlpW2TBATjiBmfjIyuZUukvRrYZU=
+github.com/kapetan-io/tackle v0.13.0/go.mod h1:5ZGq3U/Qgpq0ccxyx2+Zovg2ceM9yl6DOVL2R90of4g=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=


### PR DESCRIPTION
### Purpose
Update the tackle dependency from v0.9.0 to v0.13.0 to fix a race condition in the frozen clock implementation that was detected during test execution.

### Implementation
- Updated `go.mod` to use `github.com/kapetan-io/tackle v0.13.0`
- The new version includes a fix for `frozenTimer.Reset()` that properly synchronizes writes to the timer's `when` field

### Race Condition Details
The race occurred when multiple goroutines (specifically different LifeCycle instances) called `timer.Reset()` concurrently on their respective timers. The issue was:

- **Write (unsynchronized)**: Line 176 in old code wrote to `t.when` without holding a lock
- **Read (synchronized)**: Line 147 in `unlockedStartTimer()` read from `t.when` while holding `ft.mu`

This created a data race where one goroutine could be writing to `t.when` while another was reading it to sort timers.

### Fix Applied in tackle v0.13.0
The fix wraps the `t.when` write with the same mutex that protects reads:

```go
func (t *frozenTimer) Reset(d time.Duration) bool {
    active := t.ft.stopTimer(t)
    
    t.ft.mu.Lock()
    t.when = t.ft.now.Add(d)  // Now protected by mutex
    t.ft.mu.Unlock()
    
    t.ft.startTimer(t)
    return active
}
```

### Testing
- ✅ All tests pass with race detector enabled
- ✅ Specifically tested `TestQueue/InMemory/Timeout/MaxAttempts` 5 times with `-race` flag
- ✅ No race conditions detected

Related PR in tackle: https://github.com/kapetan-io/tackle/pull/7