### PR TITLE
Fix race condition in MemoryPartition iterator methods

### DIFF
--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -317,11 +317,13 @@ func (m *MemoryPartition) UpdateQueueInfo(info types.QueueInfo) {
 }
 
 func (m *MemoryPartition) ScanForScheduled(_ clock.Duration, now clock.Time) iter.Seq[types.Action] {
-	defer m.mu.RUnlock()
 	m.mu.RLock()
+	memCopy := make([]types.Item, len(m.mem))
+	copy(memCopy, m.mem)
+	m.mu.RUnlock()
 
 	return func(yield func(types.Action) bool) {
-		for _, item := range m.mem {
+		for _, item := range memCopy {
 			// Skip non-scheduled items
 			if item.EnqueueAt.IsZero() {
 				continue
@@ -343,11 +345,13 @@ func (m *MemoryPartition) ScanForScheduled(_ clock.Duration, now clock.Time) ite
 }
 
 func (m *MemoryPartition) ScanForActions(_ clock.Duration, now clock.Time) iter.Seq[types.Action] {
-	defer m.mu.RUnlock()
 	m.mu.RLock()
+	memCopy := make([]types.Item, len(m.mem))
+	copy(memCopy, m.mem)
+	m.mu.RUnlock()
 
 	return func(yield func(types.Action) bool) {
-		for _, item := range m.mem {
+		for _, item := range memCopy {
 			// Skip scheduled items
 			if !item.EnqueueAt.IsZero() {
 				continue


### PR DESCRIPTION
### Purpose
Fix a data race in `MemoryPartition.ScanForActions()` and `MemoryPartition.ScanForScheduled()` that was detected during fuzz testing.

### Implementation
- Modified `ScanForActions()` to create a copy of `m.mem` before releasing the read lock
- Modified `ScanForScheduled()` to create a copy of `m.mem` before releasing the read lock
- The iterator closures now safely operate on the copy instead of shared memory

### Root Cause
Both methods were using `defer m.mu.RUnlock()` which released the lock when the function returned, but the returned iterator closure still accessed `m.mem` after the lock was released. This created a race with concurrent writes from `Lease()`, `Produce()`, and other methods.

### Testing
- Verified fix with `go test -race -fuzz=FuzzQueueInvariant -fuzztime=10s`
- No race conditions detected after the fix
- All tests pass

### Why BadgerPartition Unaffected
BadgerDB uses MVCC (Multi-Version Concurrency Control) where iteration happens inside transaction callbacks, providing automatic snapshot isolation.