### PR TITLE
Add linearizability tests using Porcupine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kapetan-io/querator
 go 1.25.0
 
 require (
+	github.com/anishathalye/porcupine v1.1.0
 	github.com/dgraph-io/badger/v4 v4.3.0
 	github.com/duh-rpc/duh-go v0.9.1
 	github.com/dustin/go-humanize v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/anishathalye/porcupine v1.1.0 h1:jkMLqDejaWqvhvjxYKyqwQO3d1Jw+/08wHiIw0O4wcU=
+github.com/anishathalye/porcupine v1.1.0/go.mod h1:WM0SsFjWNl2Y4BqHr/E/ll2yY1GY1jqn+W7Z/84Zoog=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/service/linearizability_model_test.go
+++ b/service/linearizability_model_test.go
@@ -1,0 +1,145 @@
+package service_test
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/anishathalye/porcupine"
+)
+
+// --- Operation types for Porcupine ---
+
+const (
+	opProduce  = "produce"
+	opLease    = "lease"
+	opComplete = "complete"
+)
+
+type linInput struct {
+	op  string
+	ids []string // produce: IDs of items produced; complete: IDs to complete; lease: unused
+}
+
+type linOutput struct {
+	ids []string // lease: IDs returned (in order); produce/complete: nil
+	ok  bool     // false only when lease returns empty
+}
+
+// --- Sequential state ---
+
+type linState struct {
+	queue  []string
+	leased map[string]bool
+}
+
+func (s linState) clone() linState {
+	q := make([]string, len(s.queue))
+	copy(q, s.queue)
+	l := make(map[string]bool, len(s.leased))
+	for k, v := range s.leased {
+		l[k] = v
+	}
+	return linState{queue: q, leased: l}
+}
+
+// --- Porcupine model ---
+
+var linearizabilityModel = porcupine.Model{
+	Init: func() interface{} {
+		return linState{
+			queue:  []string{},
+			leased: make(map[string]bool),
+		}
+	},
+
+	Step: func(state, input, output interface{}) (bool, interface{}) {
+		s := state.(linState)
+		inp := input.(linInput)
+		out := output.(linOutput)
+
+		switch inp.op {
+		case opProduce:
+			next := s.clone()
+			next.queue = append(next.queue, inp.ids...)
+			return true, next
+
+		case opLease:
+			if !out.ok {
+				return len(s.queue) == 0, s
+			}
+			if len(out.ids) > len(s.queue) {
+				return false, s
+			}
+			for i, id := range out.ids {
+				if s.queue[i] != id {
+					return false, s
+				}
+			}
+			next := s.clone()
+			next.queue = next.queue[len(out.ids):]
+			for _, id := range out.ids {
+				next.leased[id] = true
+			}
+			return true, next
+
+		case opComplete:
+			for _, id := range inp.ids {
+				if !s.leased[id] {
+					return false, s
+				}
+			}
+			next := s.clone()
+			for _, id := range inp.ids {
+				delete(next.leased, id)
+			}
+			return true, next
+		}
+		return false, s
+	},
+
+	Equal: func(s1, s2 interface{}) bool {
+		a := s1.(linState)
+		b := s2.(linState)
+		if !slices.Equal(a.queue, b.queue) {
+			return false
+		}
+		if len(a.leased) != len(b.leased) {
+			return false
+		}
+		for k := range a.leased {
+			if !b.leased[k] {
+				return false
+			}
+		}
+		return true
+	},
+
+	DescribeOperation: func(input, output interface{}) string {
+		inp := input.(linInput)
+		out := output.(linOutput)
+		switch inp.op {
+		case opProduce:
+			return fmt.Sprintf("produce(%s)", strings.Join(inp.ids, ","))
+		case opLease:
+			if !out.ok {
+				return "lease() -> empty"
+			}
+			return fmt.Sprintf("lease() -> [%s]", strings.Join(out.ids, ","))
+		case opComplete:
+			return fmt.Sprintf("complete(%s)", strings.Join(inp.ids, ","))
+		}
+		return "<unknown>"
+	},
+
+	DescribeState: func(state interface{}) string {
+		s := state.(linState)
+		leased := make([]string, 0, len(s.leased))
+		for k := range s.leased {
+			leased = append(leased, k)
+		}
+		return fmt.Sprintf("queue=[%s] leased=[%s]",
+			strings.Join(s.queue, ","),
+			strings.Join(leased, ","))
+	},
+}

--- a/service/linearizability_model_test.go
+++ b/service/linearizability_model_test.go
@@ -14,6 +14,7 @@ const (
 	opProduce  = "produce"
 	opLease    = "lease"
 	opComplete = "complete"
+	opRetry    = "retry"
 )
 
 type linInput struct {
@@ -94,6 +95,23 @@ var linearizabilityModel = porcupine.Model{
 				delete(next.leased, id)
 			}
 			return true, next
+
+		case opRetry:
+			for _, id := range inp.ids {
+				if !s.leased[id] {
+					return false, s
+				}
+			}
+			next := s.clone()
+			for _, id := range inp.ids {
+				delete(next.leased, id)
+			}
+			// Per ADR 0022: retried items go to the head of the queue.
+			// Prepend in reverse so first item in the request ends up at position 0.
+			for i := len(inp.ids) - 1; i >= 0; i-- {
+				next.queue = append([]string{inp.ids[i]}, next.queue...)
+			}
+			return true, next
 		}
 		return false, s
 	},
@@ -128,6 +146,8 @@ var linearizabilityModel = porcupine.Model{
 			return fmt.Sprintf("lease() -> [%s]", strings.Join(out.ids, ","))
 		case opComplete:
 			return fmt.Sprintf("complete(%s)", strings.Join(inp.ids, ","))
+		case opRetry:
+			return fmt.Sprintf("retry(%s)", strings.Join(inp.ids, ","))
 		}
 		return "<unknown>"
 	},

--- a/service/linearizability_model_test.go
+++ b/service/linearizability_model_test.go
@@ -11,10 +11,11 @@ import (
 // --- Operation types for Porcupine ---
 
 const (
-	opProduce  = "produce"
-	opLease    = "lease"
-	opComplete = "complete"
-	opRetry    = "retry"
+	opProduce     = "produce"
+	opLease       = "lease"
+	opComplete    = "complete"
+	opRetry       = "retry"
+	opLeaseExpiry = "lease-expiry"
 )
 
 type linInput struct {
@@ -96,7 +97,7 @@ var linearizabilityModel = porcupine.Model{
 			}
 			return true, next
 
-		case opRetry:
+		case opRetry, opLeaseExpiry:
 			for _, id := range inp.ids {
 				if !s.leased[id] {
 					return false, s
@@ -106,7 +107,7 @@ var linearizabilityModel = porcupine.Model{
 			for _, id := range inp.ids {
 				delete(next.leased, id)
 			}
-			// Per ADR 0022: retried items go to the head of the queue.
+			// Per ADR 0022: retried and lease-expired items go to the head of the queue.
 			// Prepend in reverse so first item in the request ends up at position 0.
 			for i := len(inp.ids) - 1; i >= 0; i-- {
 				next.queue = append([]string{inp.ids[i]}, next.queue...)
@@ -148,6 +149,8 @@ var linearizabilityModel = porcupine.Model{
 			return fmt.Sprintf("complete(%s)", strings.Join(inp.ids, ","))
 		case opRetry:
 			return fmt.Sprintf("retry(%s)", strings.Join(inp.ids, ","))
+		case opLeaseExpiry:
+			return fmt.Sprintf("expiry(%s)", strings.Join(inp.ids, ","))
 		}
 		return "<unknown>"
 	},

--- a/service/linearizability_test.go
+++ b/service/linearizability_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 	"sync"
@@ -195,6 +196,194 @@ func testLinearizability(t *testing.T, setup NewStorageFunc, tearDown func()) {
 					})
 					mu.Unlock()
 					opCount.Add(1)
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		t.Logf("recorded %d operations", len(history))
+
+		result, info := porcupine.CheckOperationsVerbose(linearizabilityModel, history, 30*time.Second)
+		t.Logf("porcupine result: %s", result)
+
+		if result != porcupine.Ok {
+			name := strings.ReplaceAll(t.Name(), "/", "_")
+			path := fmt.Sprintf("testdata/linearization_%s.html", name)
+			if err := os.MkdirAll("testdata", 0755); err == nil {
+				if err := porcupine.VisualizePath(linearizabilityModel, info, path); err == nil {
+					t.Logf("visualization written to %s", path)
+				}
+			}
+		}
+
+		require.Equal(t, porcupine.Ok, result, "history is not linearizable")
+	})
+
+	t.Run("ProduceLeaseRetryComplete", func(t *testing.T) {
+		d, c, ctx := newDaemon(t, 60*clock.Second, svc.Config{StorageConfig: setup()})
+		defer func() {
+			d.Shutdown(t)
+			tearDown()
+		}()
+
+		queueName := random.String("lin-", 10)
+		createQueueAndWait(t, ctx, c, &pb.QueueInfo{
+			QueueName:           queueName,
+			LeaseTimeout:        "5m0s",
+			ExpireTimeout:       ExpireTimeout,
+			MaxAttempts:         0,
+			RequestedPartitions: 1,
+		})
+
+		const (
+			numItems     = 30
+			numConsumers = 4
+			retryPercent = 40
+		)
+
+		var history []porcupine.Operation
+		for i := range numItems {
+			id := fmt.Sprintf("item-%d", i)
+			call := time.Now().UnixNano()
+
+			require.NoError(t, c.QueueProduce(ctx, &pb.QueueProduceRequest{
+				QueueName:      queueName,
+				RequestTimeout: "5s",
+				Items: []*pb.QueueProduceItem{
+					{
+						Reference: id,
+						Bytes:     []byte(id),
+					},
+				},
+			}))
+			history = append(history, porcupine.Operation{
+				ClientId: 0,
+				Input:    linInput{op: opProduce, ids: []string{id}},
+				Call:     call,
+				Output:   linOutput{ok: true},
+				Return:   time.Now().UnixNano(),
+			})
+		}
+
+		var (
+			mu        sync.Mutex
+			completed atomic.Int64
+			wg        sync.WaitGroup
+		)
+
+		for ci := range numConsumers {
+			clientID := ci + 1
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				rng := rand.New(rand.NewSource(int64(ci)))
+				leaseClientID := random.String("lin-client-", 10)
+
+				for completed.Load() < int64(numItems) {
+					call := time.Now().UnixNano()
+
+					var lease pb.QueueLeaseResponse
+					err := c.QueueLease(ctx, &pb.QueueLeaseRequest{
+						QueueName:      queueName,
+						ClientId:       leaseClientID,
+						RequestTimeout: "1s",
+						BatchSize:      1,
+					}, &lease)
+					if err != nil {
+						if ctx.Err() != nil {
+							return
+						}
+						var de duh.Error
+						if errors.As(err, &de) && de.Code() == duh.CodeRetryRequest {
+							continue
+						}
+						t.Errorf("consumer %d lease: %v", ci, err)
+						return
+					}
+
+					if len(lease.Items) == 0 {
+						mu.Lock()
+						history = append(history, porcupine.Operation{
+							ClientId: clientID,
+							Input:    linInput{op: opLease},
+							Call:     call,
+							Output:   linOutput{ok: false},
+							Return:   time.Now().UnixNano(),
+						})
+						mu.Unlock()
+						continue
+					}
+
+					itemID := string(lease.Items[0].Bytes)
+					mu.Lock()
+					history = append(history, porcupine.Operation{
+						ClientId: clientID,
+						Input:    linInput{op: opLease},
+						Call:     call,
+						Output:   linOutput{ids: []string{itemID}, ok: true},
+						Return:   time.Now().UnixNano(),
+					})
+					mu.Unlock()
+
+					if rng.Intn(100) < retryPercent {
+						retryInp := linInput{op: opRetry, ids: []string{itemID}}
+						retryCall := time.Now().UnixNano()
+
+						err = c.QueueRetry(ctx, &pb.QueueRetryRequest{
+							QueueName: queueName,
+							Partition: lease.Partition,
+							Items: []*pb.QueueRetryItem{
+								{Id: lease.Items[0].Id},
+							},
+						})
+						if err != nil {
+							if ctx.Err() != nil {
+								return
+							}
+							t.Errorf("consumer %d retry: %v", ci, err)
+							return
+						}
+
+						mu.Lock()
+						history = append(history, porcupine.Operation{
+							ClientId: clientID,
+							Input:    retryInp,
+							Call:     retryCall,
+							Output:   linOutput{ok: true},
+							Return:   time.Now().UnixNano(),
+						})
+						mu.Unlock()
+						continue
+					}
+
+					compInp := linInput{op: opComplete, ids: []string{itemID}}
+					compCall := time.Now().UnixNano()
+
+					err = c.QueueComplete(ctx, &pb.QueueCompleteRequest{
+						QueueName:      queueName,
+						Partition:      lease.Partition,
+						RequestTimeout: "5s",
+						Ids:            []string{lease.Items[0].Id},
+					})
+					if err != nil {
+						if ctx.Err() != nil {
+							return
+						}
+						t.Errorf("consumer %d complete: %v", ci, err)
+						return
+					}
+
+					mu.Lock()
+					history = append(history, porcupine.Operation{
+						ClientId: clientID,
+						Input:    compInp,
+						Call:     compCall,
+						Output:   linOutput{ok: true},
+						Return:   time.Now().UnixNano(),
+					})
+					mu.Unlock()
+					completed.Add(1)
 				}
 			}()
 		}

--- a/service/linearizability_test.go
+++ b/service/linearizability_test.go
@@ -1,0 +1,221 @@
+package service_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/anishathalye/porcupine"
+	"github.com/duh-rpc/duh-go"
+	"github.com/kapetan-io/querator/internal/store"
+	pb "github.com/kapetan-io/querator/proto"
+	svc "github.com/kapetan-io/querator/service"
+	"github.com/kapetan-io/tackle/clock"
+	"github.com/kapetan-io/tackle/random"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestLinearizability(t *testing.T) {
+	badgerdb := badgerTestSetup{Dir: t.TempDir()}
+
+	for _, tc := range []struct {
+		Setup    NewStorageFunc
+		TearDown func()
+		Name     string
+	}{
+		{
+			Name: "InMemory",
+			Setup: func() store.Config {
+				return setupMemoryStorage(store.Config{})
+			},
+			TearDown: func() {},
+		},
+		{
+			Name: "BadgerDB",
+			Setup: func() store.Config {
+				return badgerdb.Setup(store.BadgerConfig{})
+			},
+			TearDown: func() {
+				badgerdb.Teardown()
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			testLinearizability(t, tc.Setup, tc.TearDown)
+		})
+	}
+}
+
+func testLinearizability(t *testing.T, setup NewStorageFunc, tearDown func()) {
+	defer goleak.VerifyNone(t, goleakOptions...)
+
+	t.Run("ProduceLeaseComplete", func(t *testing.T) {
+		d, c, ctx := newDaemon(t, 30*clock.Second, svc.Config{StorageConfig: setup()})
+		defer func() {
+			d.Shutdown(t)
+			tearDown()
+		}()
+
+		queueName := random.String("lin-", 10)
+		createQueueAndWait(t, ctx, c, &pb.QueueInfo{
+			QueueName:           queueName,
+			LeaseTimeout:        "5m0s",
+			ExpireTimeout:       ExpireTimeout,
+			RequestedPartitions: 1,
+		})
+
+		const (
+			numItems     = 50
+			numConsumers = 4
+		)
+
+		// Pre-produce items sequentially so their FIFO order is unambiguous.
+		var history []porcupine.Operation
+		for i := range numItems {
+			id := fmt.Sprintf("item-%d", i)
+			call := time.Now().UnixNano()
+
+			require.NoError(t, c.QueueProduce(ctx, &pb.QueueProduceRequest{
+				QueueName:      queueName,
+				RequestTimeout: "5s",
+				Items: []*pb.QueueProduceItem{
+					{
+						Reference: id,
+						Bytes:     []byte(id),
+					},
+				},
+			}))
+			history = append(history, porcupine.Operation{
+				ClientId: 0,
+				Input:    linInput{op: opProduce, ids: []string{id}},
+				Call:     call,
+				Output:   linOutput{ok: true},
+				Return:   time.Now().UnixNano(),
+			})
+		}
+
+		// Concurrent consumers race to lease and complete items.
+		var (
+			mu      sync.Mutex
+			opCount atomic.Int64
+			wg      sync.WaitGroup
+		)
+
+		for ci := range numConsumers {
+			clientID := ci + 1
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				leaseClientID := random.String("lin-client-", 10)
+				for opCount.Load() < int64(numItems) {
+					inp := linInput{op: opLease}
+					call := time.Now().UnixNano()
+
+					var lease pb.QueueLeaseResponse
+					err := c.QueueLease(ctx, &pb.QueueLeaseRequest{
+						QueueName:      queueName,
+						ClientId:       leaseClientID,
+						RequestTimeout: "1s",
+						BatchSize:      1,
+					}, &lease)
+					if err != nil {
+						if ctx.Err() != nil {
+							return
+						}
+						var de duh.Error
+						if errors.As(err, &de) && de.Code() == duh.CodeRetryRequest {
+							continue
+						}
+						t.Errorf("consumer %d lease: %v", ci, err)
+						return
+					}
+
+					if len(lease.Items) == 0 {
+						mu.Lock()
+						history = append(history, porcupine.Operation{
+							ClientId: clientID,
+							Input:    inp,
+							Call:     call,
+							Output:   linOutput{ok: false},
+							Return:   time.Now().UnixNano(),
+						})
+						mu.Unlock()
+						continue
+					}
+
+					ids := make([]string, len(lease.Items))
+					for i, item := range lease.Items {
+						ids[i] = string(item.Bytes)
+					}
+					mu.Lock()
+					history = append(history, porcupine.Operation{
+						ClientId: clientID,
+						Input:    inp,
+						Call:     call,
+						Output:   linOutput{ids: ids, ok: true},
+						Return:   time.Now().UnixNano(),
+					})
+					mu.Unlock()
+
+					completeIDs := make([]string, len(lease.Items))
+					for i, item := range lease.Items {
+						completeIDs[i] = item.Id
+					}
+
+					compInp := linInput{op: opComplete, ids: ids}
+					compCall := time.Now().UnixNano()
+
+					err = c.QueueComplete(ctx, &pb.QueueCompleteRequest{
+						QueueName:      queueName,
+						Partition:      lease.Partition,
+						RequestTimeout: "5s",
+						Ids:            completeIDs,
+					})
+					if err != nil {
+						if ctx.Err() != nil {
+							return
+						}
+						t.Errorf("consumer %d complete: %v", ci, err)
+						return
+					}
+
+					mu.Lock()
+					history = append(history, porcupine.Operation{
+						ClientId: clientID,
+						Input:    compInp,
+						Call:     compCall,
+						Output:   linOutput{ok: true},
+						Return:   time.Now().UnixNano(),
+					})
+					mu.Unlock()
+					opCount.Add(1)
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		t.Logf("recorded %d operations", len(history))
+
+		result, info := porcupine.CheckOperationsVerbose(linearizabilityModel, history, 30*time.Second)
+		t.Logf("porcupine result: %s", result)
+
+		if result != porcupine.Ok {
+			name := strings.ReplaceAll(t.Name(), "/", "_")
+			path := fmt.Sprintf("testdata/linearization_%s.html", name)
+			if err := os.MkdirAll("testdata", 0755); err == nil {
+				if err := porcupine.VisualizePath(linearizabilityModel, info, path); err == nil {
+					t.Logf("visualization written to %s", path)
+				}
+			}
+		}
+
+		require.Equal(t, porcupine.Ok, result, "history is not linearizable")
+	})
+}

--- a/service/linearizability_test.go
+++ b/service/linearizability_test.go
@@ -407,4 +407,224 @@ func testLinearizability(t *testing.T, setup NewStorageFunc, tearDown func()) {
 
 		require.Equal(t, porcupine.Ok, result, "history is not linearizable")
 	})
+
+	t.Run("LeaseExpiry", func(t *testing.T) {
+		d, c, ctx := newDaemon(t, 60*clock.Second, svc.Config{StorageConfig: setup()})
+		defer func() {
+			d.Shutdown(t)
+			tearDown()
+		}()
+
+		const leaseTimeout = 300 * time.Millisecond
+
+		queueName := random.String("lin-", 10)
+		createQueueAndWait(t, ctx, c, &pb.QueueInfo{
+			QueueName:           queueName,
+			LeaseTimeout:        leaseTimeout.String(),
+			ExpireTimeout:       ExpireTimeout,
+			MaxAttempts:         0,
+			RequestedPartitions: 1,
+		})
+
+		const (
+			numItems     = 40
+			numStallers  = 5
+			numConsumers = 2
+		)
+
+		var history []porcupine.Operation
+		for i := range numItems {
+			id := fmt.Sprintf("item-%d", i)
+			call := time.Now().UnixNano()
+
+			require.NoError(t, c.QueueProduce(ctx, &pb.QueueProduceRequest{
+				QueueName:      queueName,
+				RequestTimeout: "5s",
+				Items: []*pb.QueueProduceItem{
+					{
+						Reference: id,
+						Bytes:     []byte(id),
+					},
+				},
+			}))
+			history = append(history, porcupine.Operation{
+				ClientId: 0,
+				Input:    linInput{op: opProduce, ids: []string{id}},
+				Call:     call,
+				Output:   linOutput{ok: true},
+				Return:   time.Now().UnixNano(),
+			})
+		}
+
+		var (
+			mu        sync.Mutex
+			completed atomic.Int64
+			stallerWg sync.WaitGroup
+			wg        sync.WaitGroup
+		)
+
+		// Stallers: lease one item each, then let the lease expire.
+		// They grab the first items from the head before consumers start.
+		for si := range numStallers {
+			clientID := si + 1
+			stallerWg.Add(1)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				leaseClientID := random.String("lin-stall-", 10)
+				call := time.Now().UnixNano()
+
+				var lease pb.QueueLeaseResponse
+				err := c.QueueLease(ctx, &pb.QueueLeaseRequest{
+					QueueName:      queueName,
+					ClientId:       leaseClientID,
+					RequestTimeout: "5s",
+					BatchSize:      1,
+				}, &lease)
+				if err != nil {
+					t.Errorf("staller %d lease: %v", si, err)
+					stallerWg.Done()
+					return
+				}
+				if len(lease.Items) == 0 {
+					t.Errorf("staller %d: expected 1 item, got 0", si)
+					stallerWg.Done()
+					return
+				}
+
+				itemID := string(lease.Items[0].Bytes)
+				mu.Lock()
+				history = append(history, porcupine.Operation{
+					ClientId: clientID,
+					Input:    linInput{op: opLease},
+					Call:     call,
+					Output:   linOutput{ids: []string{itemID}, ok: true},
+					Return:   time.Now().UnixNano(),
+				})
+				mu.Unlock()
+
+				// Signal that this staller has acquired its item.
+				stallerWg.Done()
+
+				// Wait for lease to expire, plus buffer for lifecycle to process.
+				leaseDeadline := time.Now().Add(leaseTimeout)
+				time.Sleep(leaseTimeout + 100*time.Millisecond)
+
+				mu.Lock()
+				history = append(history, porcupine.Operation{
+					ClientId: clientID,
+					Input:    linInput{op: opLeaseExpiry, ids: []string{itemID}},
+					Call:     leaseDeadline.UnixNano(),
+					Output:   linOutput{ok: true},
+					Return:   time.Now().UnixNano(),
+				})
+				mu.Unlock()
+			}()
+		}
+
+		// Wait for all stallers to acquire their items before starting consumers.
+		stallerWg.Wait()
+
+		// Normal consumers: lease and complete.
+		for ci := range numConsumers {
+			clientID := numStallers + ci + 1
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				leaseClientID := random.String("lin-client-", 10)
+
+				for completed.Load() < int64(numItems) {
+					call := time.Now().UnixNano()
+
+					var lease pb.QueueLeaseResponse
+					err := c.QueueLease(ctx, &pb.QueueLeaseRequest{
+						QueueName:      queueName,
+						ClientId:       leaseClientID,
+						RequestTimeout: "1s",
+						BatchSize:      1,
+					}, &lease)
+					if err != nil {
+						if ctx.Err() != nil {
+							return
+						}
+						var de duh.Error
+						if errors.As(err, &de) && de.Code() == duh.CodeRetryRequest {
+							continue
+						}
+						t.Errorf("consumer %d lease: %v", ci, err)
+						return
+					}
+
+					if len(lease.Items) == 0 {
+						mu.Lock()
+						history = append(history, porcupine.Operation{
+							ClientId: clientID,
+							Input:    linInput{op: opLease},
+							Call:     call,
+							Output:   linOutput{ok: false},
+							Return:   time.Now().UnixNano(),
+						})
+						mu.Unlock()
+						continue
+					}
+
+					itemID := string(lease.Items[0].Bytes)
+					mu.Lock()
+					history = append(history, porcupine.Operation{
+						ClientId: clientID,
+						Input:    linInput{op: opLease},
+						Call:     call,
+						Output:   linOutput{ids: []string{itemID}, ok: true},
+						Return:   time.Now().UnixNano(),
+					})
+					mu.Unlock()
+
+					err = c.QueueComplete(ctx, &pb.QueueCompleteRequest{
+						QueueName:      queueName,
+						Partition:      lease.Partition,
+						RequestTimeout: "5s",
+						Ids:            []string{lease.Items[0].Id},
+					})
+					if err != nil {
+						if ctx.Err() != nil {
+							return
+						}
+						t.Errorf("consumer %d complete: %v", ci, err)
+						return
+					}
+
+					compCall := time.Now().UnixNano()
+					mu.Lock()
+					history = append(history, porcupine.Operation{
+						ClientId: clientID,
+						Input:    linInput{op: opComplete, ids: []string{itemID}},
+						Call:     compCall,
+						Output:   linOutput{ok: true},
+						Return:   time.Now().UnixNano(),
+					})
+					mu.Unlock()
+					completed.Add(1)
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		t.Logf("recorded %d operations", len(history))
+
+		result, info := porcupine.CheckOperationsVerbose(linearizabilityModel, history, 30*time.Second)
+		t.Logf("porcupine result: %s", result)
+
+		if result != porcupine.Ok {
+			name := strings.ReplaceAll(t.Name(), "/", "_")
+			path := fmt.Sprintf("testdata/linearization_%s.html", name)
+			if err := os.MkdirAll("testdata", 0755); err == nil {
+				if err := porcupine.VisualizePath(linearizabilityModel, info, path); err == nil {
+					t.Logf("visualization written to %s", path)
+				}
+			}
+		}
+
+		require.Equal(t, porcupine.Ok, result, "history is not linearizable")
+	})
 }


### PR DESCRIPTION
### Purpose
Adds linearizability testing for Querator's queue operations using the [Porcupine](https://github.com/anishathalye/porcupine) checker. Verifies that concurrent queue operations on a single-partition FIFO queue are consistent with a valid sequential execution — proving lease exclusivity, FIFO ordering, and item conservation under concurrent access.

### Implementation

- **Porcupine model** (`linearizability_model_test.go`): Encodes strict FIFO queue semantics as a sequential specification. Operations: `produce` (append to tail), `lease` (take from head, must match FIFO order), `complete` (remove from leased set), `retry` (move to head per ADR 0022), `lease-expiry` (move to head per ADR 0022). State tracks both the ordered queue and the leased item set.

- **Phase 1 — ProduceLeaseComplete**: Pre-produces 50 items sequentially (unambiguous FIFO order), then spawns 4 concurrent consumers racing to lease and complete them. Verifies FIFO ordering and lease exclusivity under concurrent access.

- **Phase 2 — ProduceLeaseRetryComplete**: Pre-produces 30 items, 4 concurrent consumers randomly retry 40% of leased items before eventually completing. Model encodes retry-to-head semantics per ADR 0022. Note: the known retry-in-place bug is difficult to detect via black-box linearizability testing because completed items are removed from storage, leaving the retried item at the effective head by coincidence.

- **Phase 3 — LeaseExpiry**: 5 staller goroutines lease items and let them expire (300ms lease timeout), while 2 normal consumers race to lease and complete all 40 items. Verifies item conservation (no items lost across expiry), lease exclusivity (no double-leasing during or after expiry), and absence of phantom deliveries. Note: head-vs-tail ordering for expired items cannot be detected via linearizability checking because expiry is an implicit event with no directly observable linearization point — that property requires a deterministic functional test.

- On failure, writes an HTML visualization to `testdata/` for debugging
- All tests run against both InMemory and BadgerDB backends