### PR TITLE
Fix retry tail-placement and add linearizability tests

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -126,8 +126,8 @@ _Avoid_: Driver, adapter, plugin
 > **Dev:** "When a **Producer** calls produce with an **EnqueueAt** in the future, does the **Item** go into the **Partition** immediately?"
 > **Domain expert:** "Yes — the **Item** is written to the **Partition's** scheduled storage immediately. But it won't appear in the main queue until the **Lifecycle** detects that its **EnqueueAt** has passed and moves it."
 
-> **Dev:** "If a **Lease** expires, does the **Item** go back to the end of the queue?"
-> **Domain expert:** "No — to avoid head-of-line blocking, the **Lifecycle** places expired-lease **Items** at the *front* of the FIFO in that **Partition**, behind any other items already waiting."
+> **Dev:** "If a **Lease** expires, does the **Item** stay at its original position in the queue?"
+> **Domain expert:** "No — to avoid head-of-line blocking, the **Lifecycle** assigns a new ID and places expired-lease **Items** at the *tail* of the FIFO in that **Partition**. This ensures items already waiting in the queue take precedence over expired items."
 
 > **Dev:** "Can a scoped **API Key** access queues in a different **Namespace** if the **User** has a **Role Binding** there?"
 > **Domain expert:** "Never. A scoped key's namespace acts as a hard boolean filter — it's mathematically impossible regardless of the user's permissions elsewhere."

--- a/docs/adr/0022-managing-item-lifecycles.md
+++ b/docs/adr/0022-managing-item-lifecycles.md
@@ -78,23 +78,28 @@ future if warranted.
 When an item exceeds its `leased_deadline`, the naive solution might be to simply reset the
 `leased_deadline` and mark the item as `is_leased=false`. However, this approach compromises
 the First-In-First-Out (FIFO) nature of the queue. If leased items which have exceeded their 
-leases are NOT explicitly placed at the beginning of the queue, they will naturally take 
-precedence over new or other existing items in the queue, thus violating the FIFO nature of the
+leases are left at their original position in the queue, they will naturally take 
+precedence over newer items waiting behind them, thus violating the FIFO nature of the
 queue. This is commonly referred to as [Head-of-line (HOL) blocking](https://en.wikipedia.org/wiki/Head-of-line_blocking).
 
 In order to avoid HOL, and maintain FIFO integrity, if an item fails to be completed before its 
-`leased_deadline` is exceeded, it should be placed at the beginning of the FIFO queue when it is 
+`leased_deadline` is exceeded, it should be placed at the tail of the FIFO queue when it is 
 returned to an un-leased status. This ensures that items already in the queue take precedence 
-over such items and pleases FIFO behavior. 
+over such items and preserves FIFO behavior. 
 
 Consider a failure scenario where thousands of leased items exceed their `leased_deadline` and are
 returned to an un-leased status by the lifecycle. If these previously leased items are not placed
-at the beginning of the queue, the flood of un-leased items which appear at the end of the queue
-could starve out items that exist further up the queue such that their processing is delayed. 
-This could also create a cycle where leased items never complete processing, while also
-saturating all consumers, denying other items in the queue the chance to be processed and completed. 
-As a result, items that would normally be processed do not get the opportunity to be handled by 
-consumers and thus item processing is delayed.
+at the tail of the queue but instead remain at their original positions near the front, the flood 
+of un-leased items could starve out newer items waiting further back in the queue such that their 
+processing is delayed. This could also create a cycle where leased items never complete processing, 
+while also saturating all consumers, denying other items in the queue the chance to be processed 
+and completed. As a result, items that would normally be processed do not get the opportunity to 
+be handled by consumers and thus item processing is delayed.
+
+The same HOL blocking concern applies to client-initiated retry. When a consumer retries an item,
+it should be assigned a new ID (per [ADR 0004](0004-item-id-is-not-immutable.md)) and placed at
+the tail of the queue. If the retried item were left at its original position, it would take
+precedence over newer items waiting behind it — the same HOL blocking problem described above.
 
 ## Consequences
 Because the life cycle runs its first phase in a separate Go routine, all querator storage systems
@@ -109,7 +114,7 @@ gained by this design outweighs any deficiencies incurred by the delayed handlin
 leases.
 
 #### Order Of Operation Integrity
-The decision to force items which exceed the `leased_deadline` to be re-queued at the beginning of the queue
+The decision to force items which exceed the `leased_deadline` to be re-queued at the tail of the queue
 can have a negative impact on items which MUST be processed in a specific order.
 
 Consider a queue with 3 items which are commands to be completed in order
@@ -124,7 +129,7 @@ which fails to be processed as completed will block all other items from being p
 is processed to completion. 
 
 In the future, we may want to support marking leased items which exceed their `leased_deadline` without
-placing them at the beginning of the queue. Thus preserving their place at the end of the queue. This is
+placing them at the tail of the queue. Thus preserving their original position in the queue. This is
 currently not a priority as it is my opinion that such scenario can be avoided by having `Item 1` enqueue
 `Item 2` only when `Item 1` is complete, thus avoiding this problem, and ensuring order of operation
 is preserved while not blocking other items in the queue waiting to be processed.

--- a/internal/store/badger.go
+++ b/internal/store/badger.go
@@ -331,7 +331,8 @@ nextBatch:
 			item.IsLeased = false
 			item.LeaseDeadline = clock.Time{}
 
-			if retryItem.Dead {
+			switch {
+			case retryItem.Dead:
 				if item.SourceID != nil {
 					sourceKey := []byte("source:" + string(item.SourceID))
 					if err = txn.Delete(sourceKey); err != nil {
@@ -341,7 +342,7 @@ nextBatch:
 				if err = txn.Delete(retryItem.ID); err != nil {
 					return errors.Errorf("during Delete(%s): %w", retryItem.ID, err)
 				}
-			} else if !retryItem.RetryAt.IsZero() {
+			case !retryItem.RetryAt.IsZero():
 				now := clock.Now().UTC()
 				if retryItem.RetryAt.Before(now.Add(time.Millisecond * 100)) {
 					// Immediate retry: assign new KSUID and place at tail (ADR 0022)
@@ -373,7 +374,7 @@ nextBatch:
 						return errors.Errorf("during Set(%s): %w", retryItem.ID, err)
 					}
 				}
-			} else {
+			default:
 				// Immediate retry (no RetryAt): assign new KSUID and place at tail (ADR 0022)
 				item.IsLeased = false
 				item.LeaseDeadline = clock.Time{}
@@ -877,7 +878,9 @@ func (b *BadgerPartition) TakeAction(_ context.Context, batch types.LifeCycleBat
 					item.LeaseDeadline = clock.Time{}
 					item.IsLeased = false
 
-					// Assign a new ID to the item, as it is placed at the start of the queue
+					// Assign a new ID to the item so it sorts after all existing items,
+					// placing it at the tail of the queue to avoid head-of-line blocking.
+					// See docs/adr/0022-managing-item-lifecycles.md for an explanation.
 					b.uid = b.uid.Next()
 					item.ID = []byte(b.uid.String())
 

--- a/internal/store/badger.go
+++ b/internal/store/badger.go
@@ -326,11 +326,6 @@ nextBatch:
 				continue nextBatch
 			}
 
-			// Clear lease status (attempts incremented on next lease)
-			
-			item.IsLeased = false
-			item.LeaseDeadline = clock.Time{}
-
 			switch {
 			case retryItem.Dead:
 				if item.SourceID != nil {

--- a/internal/store/badger.go
+++ b/internal/store/badger.go
@@ -341,28 +341,53 @@ nextBatch:
 				if err = txn.Delete(retryItem.ID); err != nil {
 					return errors.Errorf("during Delete(%s): %w", retryItem.ID, err)
 				}
-			} else {
-				// For scheduled retry or immediate retry, update the item
-				if !retryItem.RetryAt.IsZero() {
-					// If RetryAt is in the past or less than 100ms from now, treat as immediate retry
-					now := clock.Now().UTC()
-					if retryItem.RetryAt.Before(now.Add(time.Millisecond * 100)) {
-						// Immediate retry - EnqueueAt stays zero
-						item.EnqueueAt = clock.Time{}
-					} else {
-						// Schedule for future retry
-						item.EnqueueAt = retryItem.RetryAt
+			} else if !retryItem.RetryAt.IsZero() {
+				now := clock.Now().UTC()
+				if retryItem.RetryAt.Before(now.Add(time.Millisecond * 100)) {
+					// Immediate retry: assign new KSUID and place at tail (ADR 0022)
+					item.IsLeased = false
+					item.LeaseDeadline = clock.Time{}
+					item.EnqueueAt = clock.Time{}
+					b.uid = b.uid.Next()
+					item.ID = []byte(b.uid.String())
+					var buf bytes.Buffer
+					if err := gob.NewEncoder(&buf).Encode(item); err != nil {
+						return errors.Errorf("during gob.Encode(): %w", err)
+					}
+					if err := txn.Set(item.ID, buf.Bytes()); err != nil {
+						return errors.Errorf("during Set(%s): %w", item.ID, err)
+					}
+					if err := txn.Delete(retryItem.ID); err != nil {
+						return errors.Errorf("during Delete(%s): %w", retryItem.ID, err)
+					}
+				} else {
+					// Schedule for future retry — position is irrelevant while scheduled
+					item.IsLeased = false
+					item.LeaseDeadline = clock.Time{}
+					item.EnqueueAt = retryItem.RetryAt
+					var buf bytes.Buffer
+					if err := gob.NewEncoder(&buf).Encode(item); err != nil {
+						return errors.Errorf("during gob.Encode(): %w", err)
+					}
+					if err := txn.Set(retryItem.ID, buf.Bytes()); err != nil {
+						return errors.Errorf("during Set(%s): %w", retryItem.ID, err)
 					}
 				}
-				// For immediate retry (empty RetryAt), item stays in queue with incremented attempts
-
-				// Update the item in storage
+			} else {
+				// Immediate retry (no RetryAt): assign new KSUID and place at tail (ADR 0022)
+				item.IsLeased = false
+				item.LeaseDeadline = clock.Time{}
+				b.uid = b.uid.Next()
+				item.ID = []byte(b.uid.String())
 				var buf bytes.Buffer
 				if err := gob.NewEncoder(&buf).Encode(item); err != nil {
 					return errors.Errorf("during gob.Encode(): %w", err)
 				}
-				if err := txn.Set(retryItem.ID, buf.Bytes()); err != nil {
-					return errors.Errorf("during Set(%s): %w", retryItem.ID, err)
+				if err := txn.Set(item.ID, buf.Bytes()); err != nil {
+					return errors.Errorf("during Set(%s): %w", item.ID, err)
+				}
+				if err := txn.Delete(retryItem.ID); err != nil {
+					return errors.Errorf("during Delete(%s): %w", retryItem.ID, err)
 				}
 			}
 		}

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -183,11 +183,6 @@ nextBatch:
 				continue nextBatch
 			}
 
-			// Clear lease status (attempts incremented on next lease)
-			
-			m.mem[idx].IsLeased = false
-			m.mem[idx].LeaseDeadline = clock.Time{}
-
 			if retryItem.Dead {
 				if m.mem[idx].SourceID != nil {
 					delete(m.bySourceID, string(m.mem[idx].SourceID))
@@ -197,14 +192,31 @@ nextBatch:
 				// If RetryAt is in the past or less than 100ms from now, treat as immediate retry
 				now := clock.Now().UTC()
 				if retryItem.RetryAt.Before(now.Add(time.Millisecond * 100)) {
-					// Immediate retry - EnqueueAt stays zero
-					m.mem[idx].EnqueueAt = clock.Time{}
+					// Immediate retry: assign new KSUID and place at tail (ADR 0022)
+					item := m.mem[idx]
+					item.IsLeased = false
+					item.LeaseDeadline = clock.Time{}
+					item.EnqueueAt = clock.Time{}
+					m.uid = m.uid.Next()
+					item.ID = []byte(m.uid.String())
+					m.mem = append(m.mem[:idx], m.mem[idx+1:]...)
+					m.mem = append(m.mem, item)
 				} else {
-					// Schedule for future retry
+					// Schedule for future retry — position is irrelevant while scheduled
+					m.mem[idx].IsLeased = false
+					m.mem[idx].LeaseDeadline = clock.Time{}
 					m.mem[idx].EnqueueAt = retryItem.RetryAt
 				}
+			} else {
+				// Immediate retry (no RetryAt): assign new KSUID and place at tail (ADR 0022)
+				item := m.mem[idx]
+				item.IsLeased = false
+				item.LeaseDeadline = clock.Time{}
+				m.uid = m.uid.Next()
+				item.ID = []byte(m.uid.String())
+				m.mem = append(m.mem[:idx], m.mem[idx+1:]...)
+				m.mem = append(m.mem, item)
 			}
-			// For immediate retry (empty RetryAt), item stays in queue with incremented attempts
 		}
 	}
 	return nil

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -183,12 +183,13 @@ nextBatch:
 				continue nextBatch
 			}
 
-			if retryItem.Dead {
+			switch {
+			case retryItem.Dead:
 				if m.mem[idx].SourceID != nil {
 					delete(m.bySourceID, string(m.mem[idx].SourceID))
 				}
 				m.mem = append(m.mem[:idx], m.mem[idx+1:]...)
-			} else if !retryItem.RetryAt.IsZero() {
+			case !retryItem.RetryAt.IsZero():
 				// If RetryAt is in the past or less than 100ms from now, treat as immediate retry
 				now := clock.Now().UTC()
 				if retryItem.RetryAt.Before(now.Add(time.Millisecond * 100)) {
@@ -207,7 +208,7 @@ nextBatch:
 					m.mem[idx].LeaseDeadline = clock.Time{}
 					m.mem[idx].EnqueueAt = retryItem.RetryAt
 				}
-			} else {
+			default:
 				// Immediate retry (no RetryAt): assign new KSUID and place at tail (ADR 0022)
 				item := m.mem[idx]
 				item.IsLeased = false
@@ -501,14 +502,15 @@ func (m *MemoryPartition) TakeAction(_ context.Context, batch types.LifeCycleBat
 				item.LeaseDeadline = clock.Time{}
 				item.IsLeased = false
 
-				// Assign a new ID to the item, as it is placed at the start of the queue
+				// Assign a new ID to the item so it sorts after all existing items,
+				// placing it at the tail of the queue to avoid head-of-line blocking.
+				// See docs/adr/0022-managing-item-lifecycles.md for an explanation.
 				m.uid = m.uid.Next()
 				item.ID = []byte(m.uid.String())
 
 				// Remove the item from the array
 				m.mem = append(m.mem[:idx], m.mem[idx+1:]...)
 				// Add the item to the tail of the array
-				// See docs/adr/0022-managing-item-lifecycles.md for and explanation
 				m.mem = append(m.mem, item)
 			case types.ActionDeleteItem:
 				idx, ok := m.findID(a.Item.ID)

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -928,11 +928,28 @@ nextBatch:
 				continue nextBatch
 			}
 
-			var isLeased bool
-			var enqueueAt sql.NullTime
+			item := new(types.Item)
+			var enqueueAt, leaseDeadline sql.NullTime
+			var sourceID sql.NullString
 			err := tx.QueryRow(ctx,
-				`SELECT is_leased, enqueue_at FROM `+p.tableName()+` WHERE id = $1 FOR UPDATE`,
-				retryItem.ID).Scan(&isLeased, &enqueueAt)
+				`SELECT id, source_id, is_leased, lease_deadline, enqueue_at, created_at,
+				        expire_deadline, attempts, max_attempts, reference, encoding, kind, payload
+				 FROM `+p.tableName()+` WHERE id = $1 FOR UPDATE`,
+				retryItem.ID).Scan(
+				&item.ID,
+				&sourceID,
+				&item.IsLeased,
+				&leaseDeadline,
+				&enqueueAt,
+				&item.CreatedAt,
+				&item.ExpireDeadline,
+				&item.Attempts,
+				&item.MaxAttempts,
+				&item.Reference,
+				&item.Encoding,
+				&item.Kind,
+				&item.Payload,
+			)
 
 			if err == pgx.ErrNoRows {
 				batch.Requests[i].Err = reply.NewInvalidOption("invalid storage id; '%s' does not exist", retryItem.ID)
@@ -942,7 +959,17 @@ nextBatch:
 				return errors.Errorf("failed to check lease status: %w", err)
 			}
 
-			if enqueueAt.Valid && !enqueueAt.Time.IsZero() {
+			if sourceID.Valid {
+				item.SourceID = []byte(sourceID.String)
+			}
+			if leaseDeadline.Valid {
+				item.LeaseDeadline = leaseDeadline.Time
+			}
+			if enqueueAt.Valid {
+				item.EnqueueAt = enqueueAt.Time
+			}
+
+			if !item.EnqueueAt.IsZero() {
 				if p.conf.Log != nil {
 					p.conf.Log.LogAttrs(ctx, slog.LevelWarn, "attempted to retry a scheduled item; reported does not exist",
 						slog.String("id", string(retryItem.ID)))
@@ -951,47 +978,61 @@ nextBatch:
 				continue nextBatch
 			}
 
-			if !isLeased {
+			if !item.IsLeased {
 				batch.Requests[i].Err = reply.NewConflict("item(s) cannot be retried; '%s' is not marked as leased", retryItem.ID)
 				continue nextBatch
+			}
+
+			var srcID interface{}
+			if item.SourceID != nil {
+				srcID = string(item.SourceID)
 			}
 
 			switch {
 			case retryItem.Dead:
 				_, err = tx.Exec(ctx, `DELETE FROM `+p.tableName()+` WHERE id = $1`, retryItem.ID)
-			case !retryItem.RetryAt.IsZero():
-				// If RetryAt is in the past or less than 100ms from now, treat as immediate retry
-				now := clock.Now().UTC()
-				if retryItem.RetryAt.Before(now.Add(time.Millisecond * 100)) {
-					// Immediate retry - enqueue_at stays NULL
-					_, err = tx.Exec(ctx, `
-						UPDATE `+p.tableName()+`
-						SET is_leased = false,
-							lease_deadline = NULL,
-							enqueue_at = NULL
-						WHERE id = $1`,
-						retryItem.ID)
-				} else {
-					// Schedule for future retry
-					_, err = tx.Exec(ctx, `
-						UPDATE `+p.tableName()+`
-						SET is_leased = false,
-							lease_deadline = NULL,
-							enqueue_at = $1
-						WHERE id = $2`,
-						timeToMicroseconds(retryItem.RetryAt), retryItem.ID)
+				if err != nil {
+					return errors.Errorf("during Retry() delete dead: %w", err)
 				}
-			default:
+			case !retryItem.RetryAt.IsZero() && !retryItem.RetryAt.Before(clock.Now().UTC().Add(time.Millisecond*100)):
+				// Schedule for future retry — position is irrelevant while scheduled
 				_, err = tx.Exec(ctx, `
 					UPDATE `+p.tableName()+`
 					SET is_leased = false,
-						lease_deadline = NULL
-					WHERE id = $1`,
-					retryItem.ID)
-			}
-
-			if err != nil {
-				return errors.Errorf("during Retry(): %w", err)
+						lease_deadline = NULL,
+						enqueue_at = $1
+					WHERE id = $2`,
+					timeToMicroseconds(retryItem.RetryAt), retryItem.ID)
+				if err != nil {
+					return errors.Errorf("during Retry() schedule: %w", err)
+				}
+			default:
+				// Immediate retry (no RetryAt, or RetryAt within 100ms): assign new KSUID and place at tail (ADR 0022)
+				p.uid = p.uid.Next()
+				newID := p.uid.String()
+				_, err = tx.Exec(ctx, `DELETE FROM `+p.tableName()+` WHERE id = $1`, retryItem.ID)
+				if err != nil {
+					return errors.Errorf("during Retry() delete for tail placement: %w", err)
+				}
+				_, err = tx.Exec(ctx, `
+					INSERT INTO `+p.tableName()+` (
+						id, source_id, is_leased, lease_deadline, enqueue_at,
+						created_at, expire_deadline, attempts, max_attempts,
+						reference, encoding, kind, payload
+					) VALUES ($1, $2, false, NULL, NULL, $3, $4, $5, $6, $7, $8, $9, $10)`,
+					newID,
+					srcID,
+					timeToMicroseconds(item.CreatedAt),
+					timeToMicroseconds(item.ExpireDeadline),
+					item.Attempts,
+					item.MaxAttempts,
+					item.Reference,
+					item.Encoding,
+					item.Kind,
+					item.Payload)
+				if err != nil {
+					return errors.Errorf("during Retry() insert at tail: %w", err)
+				}
 			}
 		}
 	}

--- a/service/linearizability_model_test.go
+++ b/service/linearizability_model_test.go
@@ -107,10 +107,9 @@ var linearizabilityModel = porcupine.Model{
 			for _, id := range inp.ids {
 				delete(next.leased, id)
 			}
-			// Per ADR 0022: retried and lease-expired items go to the head of the queue.
-			// Prepend in reverse so first item in the request ends up at position 0.
-			for i := len(inp.ids) - 1; i >= 0; i-- {
-				next.queue = append([]string{inp.ids[i]}, next.queue...)
+			// Per ADR 0022: retried and lease-expired items go to the tail of the queue.
+			for _, id := range inp.ids {
+				next.queue = append(next.queue, id)
 			}
 			return true, next
 		}

--- a/service/linearizability_model_test.go
+++ b/service/linearizability_model_test.go
@@ -108,9 +108,7 @@ var linearizabilityModel = porcupine.Model{
 				delete(next.leased, id)
 			}
 			// Per ADR 0022: retried and lease-expired items go to the tail of the queue.
-			for _, id := range inp.ids {
-				next.queue = append(next.queue, id)
-			}
+			next.queue = append(next.queue, inp.ids...)
 			return true, next
 		}
 		return false, s

--- a/service/retry_test.go
+++ b/service/retry_test.go
@@ -387,6 +387,172 @@ func testRetry(t *testing.T, setup NewStorageFunc, tearDown func()) {
 		assert.Equal(t, int32(2), retriedItem.Attempts)
 	})
 
+	t.Run("RetryMovesToTail", func(t *testing.T) {
+		var queueName = random.String("queue-", 10)
+		d, c, ctx := newDaemon(t, 10*clock.Second, svc.Config{StorageConfig: setup()})
+		defer func() {
+			d.Shutdown(t)
+			tearDown()
+		}()
+
+		createQueueAndWait(t, ctx, c, &pb.QueueInfo{
+			LeaseTimeout:        LeaseTimeout,
+			ExpireTimeout:       ExpireTimeout,
+			QueueName:           queueName,
+			RequestedPartitions: 1,
+		})
+
+		// Produce three items A, B, C in FIFO order
+		refA := random.String("ref-A-", 10)
+		refB := random.String("ref-B-", 10)
+		refC := random.String("ref-C-", 10)
+		require.NoError(t, c.QueueProduce(ctx, &pb.QueueProduceRequest{
+			QueueName:      queueName,
+			RequestTimeout: "1m",
+			Items: []*pb.QueueProduceItem{
+				{Reference: refA, Encoding: "utf8", Kind: "tail-test", Bytes: []byte("item-a")},
+				{Reference: refB, Encoding: "utf8", Kind: "tail-test", Bytes: []byte("item-b")},
+				{Reference: refC, Encoding: "utf8", Kind: "tail-test", Bytes: []byte("item-c")},
+			},
+		}))
+
+		// Lease batch of 1 — receive A (first item in FIFO order)
+		var firstLease pb.QueueLeaseResponse
+		require.NoError(t, c.QueueLease(ctx, &pb.QueueLeaseRequest{
+			ClientId:       random.String("client-", 10),
+			RequestTimeout: "5s",
+			QueueName:      queueName,
+			BatchSize:      1,
+		}, &firstLease))
+
+		require.Len(t, firstLease.Items, 1)
+		itemA := firstLease.Items[0]
+		assert.Equal(t, refA, itemA.Reference)
+		originalIDofA := itemA.Id
+
+		// Retry A immediately (no RetryAt)
+		require.NoError(t, c.QueueRetry(ctx, &pb.QueueRetryRequest{
+			QueueName: queueName,
+			Partition: firstLease.Partition,
+			Items: []*pb.QueueRetryItem{
+				{
+					Id:   itemA.Id,
+					Dead: false,
+				},
+			},
+		}))
+
+		// Lease batch of 3 — order must be B, C, A (A moved to tail)
+		var secondLease pb.QueueLeaseResponse
+		require.NoError(t, c.QueueLease(ctx, &pb.QueueLeaseRequest{
+			ClientId:       random.String("client-", 10),
+			RequestTimeout: "5s",
+			QueueName:      queueName,
+			BatchSize:      3,
+		}, &secondLease))
+
+		require.Len(t, secondLease.Items, 3)
+		assert.Equal(t, refB, secondLease.Items[0].Reference)
+		assert.Equal(t, refC, secondLease.Items[1].Reference)
+		assert.Equal(t, refA, secondLease.Items[2].Reference)
+
+		// Verify A has a new ID and Attempts == 2
+		retriedA := secondLease.Items[2]
+		assert.NotEqual(t, originalIDofA, retriedA.Id)
+		assert.Equal(t, int32(2), retriedA.Attempts)
+	})
+
+	t.Run("LeaseExpiryMovesToTail", func(t *testing.T) {
+		now := clock.NewProvider()
+		now.Freeze(clock.Now())
+		defer now.UnFreeze()
+
+		var queueName = random.String("queue-", 10)
+		d, c, ctx := newDaemon(t, 60*clock.Second, svc.Config{
+			StorageConfig: setup(),
+			Clock:         now,
+		})
+		defer func() {
+			d.Shutdown(t)
+			tearDown()
+		}()
+
+		createQueueAndWait(t, ctx, c, &pb.QueueInfo{
+			LeaseTimeout:        "300ms",
+			ExpireTimeout:       ExpireTimeout,
+			QueueName:           queueName,
+			RequestedPartitions: 1,
+		})
+
+		// Produce three items A, B, C in FIFO order
+		refA := random.String("ref-A-", 10)
+		refB := random.String("ref-B-", 10)
+		refC := random.String("ref-C-", 10)
+		require.NoError(t, c.QueueProduce(ctx, &pb.QueueProduceRequest{
+			QueueName:      queueName,
+			RequestTimeout: "1m",
+			Items: []*pb.QueueProduceItem{
+				{Reference: refA, Encoding: "utf8", Kind: "expiry-test", Bytes: []byte("item-a")},
+				{Reference: refB, Encoding: "utf8", Kind: "expiry-test", Bytes: []byte("item-b")},
+				{Reference: refC, Encoding: "utf8", Kind: "expiry-test", Bytes: []byte("item-c")},
+			},
+		}))
+
+		// Lease batch of 1 — receive A, store original ID
+		var firstLease pb.QueueLeaseResponse
+		require.NoError(t, c.QueueLease(ctx, &pb.QueueLeaseRequest{
+			ClientId:       random.String("client-", 10),
+			RequestTimeout: "5s",
+			QueueName:      queueName,
+			BatchSize:      1,
+		}, &firstLease))
+
+		require.Len(t, firstLease.Items, 1)
+		assert.Equal(t, refA, firstLease.Items[0].Reference)
+		originalIDofA := firstLease.Items[0].Id
+
+		// Advance the clock past the lease timeout to trigger lease expiry
+		now.Advance(2 * clock.Second)
+
+		// Poll until A is no longer leased AND has a new ID (lifecycle has processed the expiry)
+		err := retry.On(ctx, RetryTenTimes, func(ctx context.Context, i int) error {
+			var resp pb.StorageItemsListResponse
+			if err := c.StorageItemsList(ctx, queueName, 0, &resp, &querator.ListOptions{Limit: 100}); err != nil {
+				return err
+			}
+			item := findInStorageList(refA, &resp)
+			if item == nil {
+				return fmt.Errorf("item A not found in storage")
+			}
+			if item.IsLeased {
+				return fmt.Errorf("item A still leased")
+			}
+			if item.Id == originalIDofA {
+				return fmt.Errorf("item A still has original ID, lifecycle not yet processed")
+			}
+			return nil
+		})
+		require.NoError(t, err)
+
+		// Lease batch of 3 — order must be B, C, A (A moved to tail after expiry)
+		var secondLease pb.QueueLeaseResponse
+		require.NoError(t, c.QueueLease(ctx, &pb.QueueLeaseRequest{
+			ClientId:       random.String("client-", 10),
+			RequestTimeout: "5s",
+			QueueName:      queueName,
+			BatchSize:      3,
+		}, &secondLease))
+
+		require.Len(t, secondLease.Items, 3)
+		assert.Equal(t, refB, secondLease.Items[0].Reference)
+		assert.Equal(t, refC, secondLease.Items[1].Reference)
+		assert.Equal(t, refA, secondLease.Items[2].Reference)
+
+		// Verify A has a new ID
+		retriedA := secondLease.Items[2]
+		assert.NotEqual(t, originalIDofA, retriedA.Id)
+	})
+
 	t.Run("Errors", func(t *testing.T) {
 		storage := setup()
 		defer tearDown()


### PR DESCRIPTION
### Purpose

ADR 0022 requires that items returned to the queue via retry or lease expiry be placed at the tail of the partition's FIFO order to avoid head-of-line (HOL) blocking. The lease expiry path already handled this correctly in all three storage backends. The retry path did not — all three backends cleared lease fields in-place, leaving the item at its original position. This PR brings the Retry() implementation in line with ADR 0022 and adds Porcupine-based linearizability tests to verify concurrent queue correctness.

### Implementation

- **Linearizability tests**: Added Porcupine-based tests (`service/linearizability_test.go`) verifying linearizable behavior for produce/lease/complete, produce/lease/retry/complete, and lease-expiry workflows under concurrent access against InMemory and BadgerDB backends
- **Tail-placement tests**: Added `RetryMovesToTail` and `LeaseExpiryMovesToTail` functional tests in `service/retry_test.go` that verify FIFO ordering after retry and lease expiry across all three backends
- **Memory backend fix**: `MemoryPartition.Retry()` now copies the item, assigns a new KSUID via `uid.Next()`, splices out the old position, and appends to tail for immediate retry
- **Badger backend fix**: `BadgerPartition.Retry()` now assigns a new KSUID, writes at the new key via `txn.Set`, and deletes the old key via `txn.Delete` for immediate retry
- **Postgres backend fix**: `PostgresPartition.Retry()` now reads the full item row, assigns a new KSUID, DELETEs the old row, and INSERTs a new row at the tail for immediate retry
- **Linearizability model fix**: Updated the Porcupine model to append (not prepend) retried/expired items to the tail of the model queue
- **ADR 0022 updated**: Corrected stale "start/front of queue" language to "tail of queue" and added paragraph covering client-initiated retry
- **Stale comments fixed**: Corrected comments in `memory.go` and `badger.go` TakeAction that incorrectly said "start of the queue"