### PR TITLE
Configure storage backends with nested typed sections

### DIFF
--- a/cmd/querator/server.go
+++ b/cmd/querator/server.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kapetan-io/querator"
 	"github.com/kapetan-io/querator/daemon"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 var serverCommand = &cobra.Command{
@@ -48,9 +47,9 @@ func StartServer(ctx context.Context, w io.Writer) error {
 		}
 		defer func() { _ = reader.Close() }()
 
-		decoder := yaml.NewDecoder(reader)
-		if err := decoder.Decode(&file); err != nil {
-			return fmt.Errorf("while reading config file: %w", err)
+		file, err = daemon.ReadConfig(reader)
+		if err != nil {
+			return err
 		}
 		file.ConfigFile = flags.ConfigFile
 	}

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"strconv"
 	"strings"
 	"time"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/kapetan-io/tackle/clock"
 	"github.com/kapetan-io/tackle/color"
 	"github.com/kapetan-io/tackle/set"
+	"gopkg.in/yaml.v3"
 )
 
 type Config struct {
@@ -110,17 +110,52 @@ type Logging struct {
 	Handler string `yaml:"handler"`
 }
 
+// QueueStorage selects the backend that stores queue metadata. Exactly one backend section
+// (memory, badger, or mongo) may be set. When none is set, the in-memory backend is used.
 type QueueStorage struct {
-	Name   string            `yaml:"name"`
-	Driver string            `yaml:"driver"`
-	Config map[string]string `yaml:"config"`
+	Memory *MemoryConfig `yaml:"memory"`
+	Badger *BadgerConfig `yaml:"badger"`
+	Mongo  *MongoConfig  `yaml:"mongo"`
 }
 
+// PartitionStorage selects the backend for a named partition store. Exactly one backend section
+// (memory, badger, or mongo) must be set.
 type PartitionStorage struct {
-	Name     string            `yaml:"name"`
-	Driver   string            `yaml:"driver"`
-	Affinity int               `yaml:"affinity"`
-	Config   map[string]string `yaml:"config"`
+	Name     string        `yaml:"name"`
+	Affinity int           `yaml:"affinity"`
+	Memory   *MemoryConfig `yaml:"memory"`
+	Badger   *BadgerConfig `yaml:"badger"`
+	Mongo    *MongoConfig  `yaml:"mongo"`
+}
+
+// MemoryConfig configures the in-memory backend. It accepts no options; select it with an empty
+// mapping (`memory: {}`).
+type MemoryConfig struct{}
+
+// BadgerConfig configures the BadgerDB backend.
+type BadgerConfig struct {
+	StorageDir string `yaml:"storage-dir"`
+}
+
+func (c BadgerConfig) validate() error {
+	if c.StorageDir == "" {
+		return errors.New("badger: 'storage-dir' is required")
+	}
+	return nil
+}
+
+// MongoConfig configures the MongoDB backend.
+type MongoConfig struct {
+	ConnectionString string `yaml:"connection-string"`
+	Database         string `yaml:"database"`
+	MaxPoolSize      uint64 `yaml:"max-pool-size"`
+}
+
+func (c MongoConfig) validate() error {
+	if c.ConnectionString == "" {
+		return errors.New("mongo: 'connection-string' is required")
+	}
+	return nil
 }
 
 type Queue struct {
@@ -138,6 +173,20 @@ type Partition struct {
 	Partition   int    `yaml:"partition"`
 	ReadOnly    bool   `yaml:"read-only"`
 	StorageName string `yaml:"storage-name"`
+}
+
+// ReadConfig decodes a Querator YAML config from r with strict field checking enabled. Unknown or
+// misspelled keys — including a config option placed under the wrong backend — are reported as an
+// error instead of being silently ignored.
+func ReadConfig(r io.Reader) (File, error) {
+	dec := yaml.NewDecoder(r)
+	dec.KnownFields(true)
+
+	var file File
+	if err := dec.Decode(&file); err != nil {
+		return File{}, fmt.Errorf("while reading config file: %w", err)
+	}
+	return file, nil
 }
 
 func ApplyConfigFile(ctx context.Context, conf *Config, file File, w io.Writer) error {
@@ -210,31 +259,59 @@ func toLogLevel(level string) slog.Level {
 	}
 }
 
+// selected reports the name of the single backend that is set and how many are set, so callers can
+// enforce the "exactly one backend" rule with a clear error.
+func selected(memory, badger, mongo bool) (name string, count int) {
+	if memory {
+		name, count = "memory", count+1
+	}
+	if badger {
+		name, count = "badger", count+1
+	}
+	if mongo {
+		name, count = "mongo", count+1
+	}
+	return name, count
+}
+
+func backendErr(what string, count int) error {
+	if count == 0 {
+		return fmt.Errorf("%s must define exactly one backend (memory, badger, mongo)", what)
+	}
+	return fmt.Errorf("%s defines multiple backends; only one of (memory, badger, mongo) is allowed", what)
+}
+
 func setupPartitionStorage(file File, d *Config) error {
 	for _, ps := range file.PartitionStorage {
-		var s store.PartitionStore
+		name, count := selected(ps.Memory != nil, ps.Badger != nil, ps.Mongo != nil)
+		if count != 1 {
+			return backendErr(fmt.Sprintf("partition storage '%s'", ps.Name), count)
+		}
 
-		switch strings.ToLower(ps.Driver) {
+		var s store.PartitionStore
+		switch name {
 		case "memory":
 			s = store.NewMemoryPartitionStore(store.Config{}, d.Service.Log)
 		case "badger":
+			if err := ps.Badger.validate(); err != nil {
+				return err
+			}
 			s = store.NewBadgerPartitionStore(store.BadgerConfig{
-				StorageDir: ps.Config["storage-dir"],
+				StorageDir: ps.Badger.StorageDir,
 				Log:        d.Service.Log,
 			})
 		case "mongo":
-			maxPool, err := parseMaxPoolSize(ps.Config["max-pool-size"])
-			if err != nil {
+			if err := ps.Mongo.validate(); err != nil {
 				return err
 			}
 			s = store.NewMongoPartitionStore(store.MongoConfig{
-				ConnectionString: ps.Config["connection-string"],
-				Database:         ps.Config["database"],
-				MaxPoolSize:      maxPool,
+				ConnectionString: ps.Mongo.ConnectionString,
+				Database:         ps.Mongo.Database,
+				MaxPoolSize:      ps.Mongo.MaxPoolSize,
 				Log:              d.Service.Log,
 			})
 		default:
-			return fmt.Errorf("invalid driver; '%s' is not one of (Memory, Badger, Mongo)", ps.Driver)
+			return fmt.Errorf("unknown backend %q", name)
 		}
 
 		d.Service.StorageConfig.PartitionStorage = append(d.Service.StorageConfig.PartitionStorage, store.PartitionStorage{
@@ -246,41 +323,36 @@ func setupPartitionStorage(file File, d *Config) error {
 	return nil
 }
 
-// parseMaxPoolSize parses the optional Mongo max-pool-size config value. An empty value means "use
-// the driver default" (0).
-func parseMaxPoolSize(v string) (uint64, error) {
-	if v == "" {
-		return 0, nil
-	}
-	n, err := strconv.ParseUint(v, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid max-pool-size; '%s' is not a valid number: %w", v, err)
-	}
-	return n, nil
-}
-
 func setupQueueStorage(ctx context.Context, file File, conf *Config) error {
-	switch strings.ToLower(file.QueueStorage.Driver) {
-	case "memory", "":
+	qs := file.QueueStorage
+	name, count := selected(qs.Memory != nil, qs.Badger != nil, qs.Mongo != nil)
+	if count > 1 {
+		return backendErr("queue storage", count)
+	}
+
+	switch name {
+	case "", "memory":
 		conf.Service.StorageConfig.Queues = store.NewMemoryQueues(conf.Service.Log)
 	case "badger":
+		if err := qs.Badger.validate(); err != nil {
+			return err
+		}
 		conf.Service.StorageConfig.Queues = store.NewBadgerQueues(store.BadgerConfig{
-			StorageDir: file.QueueStorage.Config["storage-dir"],
+			StorageDir: qs.Badger.StorageDir,
 			Log:        conf.Service.Log,
 		})
 	case "mongo":
-		maxPool, err := parseMaxPoolSize(file.QueueStorage.Config["max-pool-size"])
-		if err != nil {
+		if err := qs.Mongo.validate(); err != nil {
 			return err
 		}
 		conf.Service.StorageConfig.Queues = store.NewMongoQueues(store.MongoConfig{
-			ConnectionString: file.QueueStorage.Config["connection-string"],
-			Database:         file.QueueStorage.Config["database"],
-			MaxPoolSize:      maxPool,
+			ConnectionString: qs.Mongo.ConnectionString,
+			Database:         qs.Mongo.Database,
+			MaxPoolSize:      qs.Mongo.MaxPoolSize,
 			Log:              conf.Service.Log,
 		})
 	default:
-		return fmt.Errorf("invalid driver; '%s' is not one of (Memory, Badger, Mongo)", file.QueueStorage.Driver)
+		return fmt.Errorf("unknown backend %q", name)
 	}
 
 	for _, queue := range file.Queues {

--- a/daemon/config_test.go
+++ b/daemon/config_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,11 +14,77 @@ import (
 	"github.com/kapetan-io/querator/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 )
 
+func TestReadConfigErrs(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			// A typo in a backend option must fail rather than silently fall back to the default.
+			name: "MisspelledKey",
+			config: `
+partition-storage:
+  - name: mongo-00
+    mongo:
+      connection-string: "mongodb://localhost:27017"
+      max-poolsize: 50
+`,
+			wantErr: "field max-poolsize not found",
+		},
+		{
+			// max-pool-size belongs to mongo; placing it under badger must fail.
+			name: "MisplacedKey",
+			config: `
+partition-storage:
+  - name: badger-00
+    badger:
+      storage-dir: /tmp/badger1
+      max-pool-size: 50
+`,
+			wantErr: "field max-pool-size not found",
+		},
+		{
+			name: "MistypedValue",
+			config: `
+queue-storage:
+  mongo:
+    connection-string: "mongodb://localhost:27017"
+    max-pool-size: not-a-number
+`,
+			wantErr: "cannot unmarshal",
+		},
+		{
+			name: "UnknownTopLevelKey",
+			config: `
+bogus-section: true
+`,
+			wantErr: "field bogus-section not found",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := daemon.ReadConfig(strings.NewReader(test.config))
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+// TestExampleConfigDecodes guards the shipped example.yaml against the strict decoder: every key it
+// documents must be a key the config structs actually accept, or operators copying it would hit an
+// "unknown field" error on startup.
+func TestExampleConfigDecodes(t *testing.T) {
+	f, err := os.Open("../example.yaml")
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+
+	_, err = daemon.ReadConfig(f)
+	require.NoError(t, err)
+}
+
 func TestApplyConfigFileErrs(t *testing.T) {
-	tests := []struct {
+	for _, test := range []struct {
 		name        string
 		file        daemon.File
 		expectedErr string
@@ -31,56 +99,78 @@ func TestApplyConfigFileErrs(t *testing.T) {
 			expectedErr: "invalid handler; 'invalid' is not one of (color, text, json)",
 		},
 		{
-			name: "InvalidPartitionStorageDriver",
+			name: "PartitionStorageNoBackend",
+			file: daemon.File{
+				PartitionStorage: []daemon.PartitionStorage{
+					{Name: "test"},
+				},
+			},
+			expectedErr: "partition storage 'test' must define exactly one backend (memory, badger, mongo)",
+		},
+		{
+			name: "PartitionStorageMultipleBackends",
 			file: daemon.File{
 				PartitionStorage: []daemon.PartitionStorage{
 					{
 						Name:   "test",
-						Driver: "invalid",
+						Memory: &daemon.MemoryConfig{},
+						Badger: &daemon.BadgerConfig{StorageDir: "/tmp/badger1"},
 					},
 				},
 			},
-			expectedErr: "invalid driver; 'invalid' is not one of (Memory, Badger, Mongo)",
+			expectedErr: "partition storage 'test' defines multiple backends; only one of (memory, badger, mongo) is allowed",
 		},
 		{
-			name: "InvalidQueueStorageDriver",
-			file: daemon.File{
-				QueueStorage: daemon.QueueStorage{
-					Driver: "invalid",
-				},
-			},
-			expectedErr: "invalid driver; 'invalid' is not one of (Memory, Badger, Mongo)",
-		},
-		{
-			name: "InvalidQueueStorageMaxPoolSize",
-			file: daemon.File{
-				QueueStorage: daemon.QueueStorage{
-					Driver: "mongo",
-					Config: map[string]string{
-						"connection-string": "mongodb://localhost:27017",
-						"max-pool-size":     "not-a-number",
-					},
-				},
-			},
-			expectedErr: "invalid max-pool-size; 'not-a-number' is not a valid number: " +
-				"strconv.ParseUint: parsing \"not-a-number\": invalid syntax",
-		},
-		{
-			name: "InvalidPartitionStorageMaxPoolSize",
+			name: "PartitionStorageMongoMissingConnectionString",
 			file: daemon.File{
 				PartitionStorage: []daemon.PartitionStorage{
 					{
-						Name:   "mongo-00",
-						Driver: "mongo",
-						Config: map[string]string{
-							"connection-string": "mongodb://localhost:27017",
-							"max-pool-size":     "not-a-number",
-						},
+						Name:  "mongo-00",
+						Mongo: &daemon.MongoConfig{Database: "querator"},
 					},
 				},
 			},
-			expectedErr: "invalid max-pool-size; 'not-a-number' is not a valid number: " +
-				"strconv.ParseUint: parsing \"not-a-number\": invalid syntax",
+			expectedErr: "mongo: 'connection-string' is required",
+		},
+		{
+			name: "PartitionStorageBadgerMissingStorageDir",
+			file: daemon.File{
+				PartitionStorage: []daemon.PartitionStorage{
+					{
+						Name:   "badger-00",
+						Badger: &daemon.BadgerConfig{},
+					},
+				},
+			},
+			expectedErr: "badger: 'storage-dir' is required",
+		},
+		{
+			name: "QueueStorageMultipleBackends",
+			file: daemon.File{
+				QueueStorage: daemon.QueueStorage{
+					Memory: &daemon.MemoryConfig{},
+					Mongo:  &daemon.MongoConfig{ConnectionString: "mongodb://localhost:27017"},
+				},
+			},
+			expectedErr: "queue storage defines multiple backends; only one of (memory, badger, mongo) is allowed",
+		},
+		{
+			name: "QueueStorageMongoMissingConnectionString",
+			file: daemon.File{
+				QueueStorage: daemon.QueueStorage{
+					Mongo: &daemon.MongoConfig{Database: "querator"},
+				},
+			},
+			expectedErr: "mongo: 'connection-string' is required",
+		},
+		{
+			name: "QueueStorageBadgerMissingStorageDir",
+			file: daemon.File{
+				QueueStorage: daemon.QueueStorage{
+					Badger: &daemon.BadgerConfig{},
+				},
+			},
+			expectedErr: "badger: 'storage-dir' is required",
 		},
 		{
 			name: "InvalidPartitionStorageReference",
@@ -88,7 +178,7 @@ func TestApplyConfigFileErrs(t *testing.T) {
 				PartitionStorage: []daemon.PartitionStorage{
 					{
 						Name:   "test",
-						Driver: "memory",
+						Memory: &daemon.MemoryConfig{},
 					},
 				},
 				Queues: []daemon.Queue{
@@ -104,13 +194,11 @@ func TestApplyConfigFileErrs(t *testing.T) {
 			},
 			expectedErr: "invalid partition storage; queue 'test-queue' references 'non-existent' which is undefined",
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	} {
+		t.Run(test.name, func(t *testing.T) {
 			conf := &daemon.Config{}
-			err := daemon.ApplyConfigFile(context.Background(), conf, tt.file, io.Discard)
-			assert.EqualError(t, err, tt.expectedErr)
+			err := daemon.ApplyConfigFile(context.Background(), conf, test.file, io.Discard)
+			assert.EqualError(t, err, test.expectedErr)
 		})
 	}
 }
@@ -124,12 +212,12 @@ func TestApplyConfigFile(t *testing.T) {
 		PartitionStorage: []daemon.PartitionStorage{
 			{
 				Name:     "mem-00",
-				Driver:   "memory",
+				Memory:   &daemon.MemoryConfig{},
 				Affinity: 0,
 			},
 		},
 		QueueStorage: daemon.QueueStorage{
-			Driver: "Memory",
+			Memory: &daemon.MemoryConfig{},
 		},
 		Queues: []daemon.Queue{
 			{
@@ -181,11 +269,11 @@ func TestApplyConfigFromYAML(t *testing.T) {
 	validConfig := `
 partition-storage:
   - name: mem-00
-    driver: Memory
+    memory: {}
     affinity: 0
 
 queue-storage:
-  driver: Memory
+  memory: {}
 
 queues:
   - name: queue-1
@@ -200,8 +288,7 @@ queues:
         read-only: false
         storage-name: mem-00
 `
-	var file daemon.File
-	err := yaml.Unmarshal([]byte(validConfig), &file)
+	file, err := daemon.ReadConfig(strings.NewReader(validConfig))
 	require.NoError(t, err)
 
 	conf := &daemon.Config{}
@@ -232,17 +319,14 @@ func TestBadgerConfig(t *testing.T) {
 	badgerConfig := `
 partition-storage:
   - name: badger-00
-    driver: Badger
     affinity: 0
-    config:
+    badger:
       storage-dir: /tmp/badger1
 queue-storage:
-  driver: badger
-  config:
+  badger:
     storage-dir: "/tmp/queue-storage"
 `
-	var file daemon.File
-	err := yaml.Unmarshal([]byte(badgerConfig), &file)
+	file, err := daemon.ReadConfig(strings.NewReader(badgerConfig))
 	require.NoError(t, err)
 
 	var conf daemon.Config
@@ -259,21 +343,18 @@ func TestMongoConfig(t *testing.T) {
 	mongoConfig := `
 partition-storage:
   - name: mongo-00
-    driver: mongo
     affinity: 1
-    config:
+    mongo:
       connection-string: "mongodb://localhost:27017"
       database: querator
-      max-pool-size: "50"
+      max-pool-size: 50
 queue-storage:
-  driver: Mongo
-  config:
+  mongo:
     connection-string: "mongodb://localhost:27017"
     database: querator
-    max-pool-size: "25"
+    max-pool-size: 25
 `
-	var file daemon.File
-	err := yaml.Unmarshal([]byte(mongoConfig), &file)
+	file, err := daemon.ReadConfig(strings.NewReader(mongoConfig))
 	require.NoError(t, err)
 
 	var conf daemon.Config

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -82,15 +82,13 @@ You can mix storage backends. For example, you could use BadgerDB for queue meta
 
 ```yaml
 queue-storage:
-  driver: badger
-  config:
+  badger:
     storage-dir: /data/queues
 
 partition-storage:
   - name: postgres-01
-    driver: postgres
     affinity: 1
-    config:
+    postgres:
       connection-string: "postgres://user:pass@localhost:5432/querator"
 ```
 
@@ -101,15 +99,13 @@ You can configure multiple partition stores with different affinities to distrib
 ```yaml
 partition-storage:
   - name: badger-01
-    driver: badger
     affinity: 3
-    config:
+    badger:
       storage-dir: /data/partitions-badger
 
   - name: postgres-01
-    driver: postgres
     affinity: 7
-    config:
+    postgres:
       connection-string: "postgres://user:pass@localhost:5432/querator"
 ```
 

--- a/docs/storage/badger.md
+++ b/docs/storage/badger.md
@@ -17,15 +17,13 @@ BadgerDB is ideal for:
 
 ```yaml
 queue-storage:
-  driver: badger
-  config:
+  badger:
     storage-dir: /data/queues
 
 partition-storage:
   - name: badger-01
-    driver: badger
     affinity: 1
-    config:
+    badger:
       storage-dir: /data/partitions
 ```
 
@@ -39,15 +37,13 @@ partition-storage:
 
 ```yaml
 queue-storage:
-  driver: badger
-  config:
+  badger:
     storage-dir: /data/queues
 
 partition-storage:
   - name: badger-01
-    driver: badger
     affinity: 1
-    config:
+    badger:
       storage-dir: /data/partitions
 ```
 
@@ -64,15 +60,13 @@ You can configure multiple BadgerDB partition stores with different storage dire
 ```yaml
 partition-storage:
   - name: badger-ssd
-    driver: badger
     affinity: 7
-    config:
+    badger:
       storage-dir: /mnt/ssd/querator
 
   - name: badger-hdd
-    driver: badger
     affinity: 3
-    config:
+    badger:
       storage-dir: /mnt/hdd/querator
 ```
 

--- a/docs/storage/memory.md
+++ b/docs/storage/memory.md
@@ -17,28 +17,28 @@ InMemory is ideal for:
 
 ```yaml
 queue-storage:
-  driver: memory
+  memory: {}
 
 partition-storage:
   - name: memory-01
-    driver: memory
     affinity: 1
+    memory: {}
 ```
 
 ### Configuration Options
 
-InMemory storage has **no configuration options**. Simply specify `driver: memory` and it works.
+InMemory storage has **no configuration options**. Simply specify `memory: {}` and it works.
 
 ### Example: Testing Setup
 
 ```yaml
 queue-storage:
-  driver: memory
+  memory: {}
 
 partition-storage:
   - name: memory-01
-    driver: memory
     affinity: 1
+    memory: {}
 ```
 
 This is the simplest possible configuration - perfect for tests and local development.
@@ -50,14 +50,13 @@ While possible, mixing InMemory with persistent storage is not recommended:
 ```yaml
 # NOT RECOMMENDED: Queue metadata persisted, but items are ephemeral
 queue-storage:
-  driver: badger
-  config:
+  badger:
     storage-dir: /data/queues
 
 partition-storage:
   - name: memory-01
-    driver: memory
     affinity: 1
+    memory: {}
 ```
 
 In this configuration, queue metadata survives restarts, but all queue items are lost. This creates confusing behavior and should be avoided.

--- a/docs/storage/mongodb.md
+++ b/docs/storage/mongodb.md
@@ -26,19 +26,17 @@ MongoDB is ideal for:
 
 ```yaml
 queue-storage:
-  driver: mongo
-  config:
+  mongo:
     connection-string: "mongodb://user:pass@localhost:27017"
     database: querator
 
 partition-storage:
   - name: mongo-01
-    driver: mongo
     affinity: 1
-    config:
+    mongo:
       connection-string: "mongodb://user:pass@localhost:27017"
       database: querator
-      max-pool-size: "50"
+      max-pool-size: 50
 ```
 
 ### Configuration Options
@@ -47,7 +45,7 @@ partition-storage:
 |--------|------|----------|---------|-------------|
 | `connection-string` | string | Yes | - | MongoDB connection URI (see format below) |
 | `database` | string | No | `querator` | Logical database name within the MongoDB server |
-| `max-pool-size` | string (integer) | No | driver default | Maximum connections in the pool per client (`0` = driver default) |
+| `max-pool-size` | integer | No | driver default | Maximum connections in the pool per client (`0` = driver default) |
 
 ### Connection String Format
 
@@ -110,11 +108,10 @@ last user closes. The `max-pool-size` setting caps connections per client.
 ```yaml
 partition-storage:
   - name: mongo-01
-    driver: mongo
-    config:
+    mongo:
       connection-string: "mongodb://user:pass@localhost:27017"
       database: querator
-      max-pool-size: "50"
+      max-pool-size: 50
 ```
 
 ## Performance Considerations

--- a/docs/storage/postgres.md
+++ b/docs/storage/postgres.md
@@ -18,16 +18,14 @@ PostgreSQL is ideal for:
 
 ```yaml
 queue-storage:
-  driver: postgres
-  config:
+  postgres:
     # sslmode=disable for local development only; use sslmode=require or higher in production
     connection-string: "postgres://user:pass@localhost:5432/querator?sslmode=disable"
 
 partition-storage:
   - name: postgres-01
-    driver: postgres
     affinity: 1
-    config:
+    postgres:
       connection-string: "postgres://user:pass@localhost:5432/querator?sslmode=disable"
       max-conns: 10
 ```
@@ -73,15 +71,13 @@ connection-string: "postgres://querator:secret@localhost:5432/querator?connect_t
 
 ```yaml
 queue-storage:
-  driver: postgres
-  config:
+  postgres:
     connection-string: "postgres://querator_user:secure_password@db-primary.internal:5432/querator?sslmode=verify-full&pool_max_conns=20"
 
 partition-storage:
   - name: postgres-01
-    driver: postgres
     affinity: 1
-    config:
+    postgres:
       connection-string: "postgres://querator_user:secure_password@db-primary.internal:5432/querator?sslmode=verify-full"
       max-conns: 50
 ```
@@ -93,16 +89,14 @@ You can distribute partitions across multiple PostgreSQL servers:
 ```yaml
 partition-storage:
   - name: postgres-us-east
-    driver: postgres
     affinity: 5
-    config:
+    postgres:
       connection-string: "postgres://user:pass@db-us-east.internal:5432/querator"
       max-conns: 50
 
   - name: postgres-us-west
-    driver: postgres
     affinity: 5
-    config:
+    postgres:
       connection-string: "postgres://user:pass@db-us-west.internal:5432/querator"
       max-conns: 50
 ```
@@ -223,8 +217,7 @@ The `max-conns` setting controls the maximum number of connections per storage b
 ```yaml
 partition-storage:
   - name: postgres-01
-    driver: postgres
-    config:
+    postgres:
       connection-string: "postgres://user:pass@localhost:5432/querator"
       max-conns: 50  # Maximum 50 connections to this database
 ```
@@ -260,8 +253,7 @@ Configure Querator with the managed service endpoint:
 ```yaml
 partition-storage:
   - name: postgres-prod
-    driver: postgres
-    config:
+    postgres:
       connection-string: "postgres://user:pass@managed-postgres.cloud:5432/querator?sslmode=require"
 ```
 

--- a/example.yaml
+++ b/example.yaml
@@ -1,7 +1,9 @@
 # This is an example config file
 
-# Querator currently supports "memory", "badger", "postgres", and "mongo" storage drivers
-# TODO: Need to document all options for each storage driver
+# Querator currently supports "memory", "badger", "postgres", and "mongo" storage drivers.
+# Each storage entry selects its backend by nesting the backend's options under a section named
+# after the backend (memory, badger, mongo). Exactly one backend section may be set per entry, and
+# unknown options are rejected at startup rather than silently ignored.
 
 # HTTP server listen address (use 0.0.0.0 for Docker)
 address: 0.0.0.0:2319
@@ -14,23 +16,24 @@ logging:
 
 # Queue Storage defines where metadata about the queues is stored
 queue-storage:
-  driver: badger
-  config:
+  badger:
     storage-dir: /data/queues
 
 # Partition Storage defines where partitions are stored
 partition-storage:
   - name: badger-01
-    driver: badger
     affinity: 1
-    config:
+    badger:
       storage-dir: /data/partitions
 
+  # The in-memory backend has no options; select it with an empty mapping.
+  #  - name: mem-01
+  #    affinity: 1
+  #    memory: {}
+
 #  - name: postgres-01
-#    driver: postgres
 #    affinity: 1
-#
-#    config:
+#    postgres:
 #      host: localhost
 #      port: 5432
 #      user: foo
@@ -43,23 +46,20 @@ partition-storage:
 # MongoDB partition storage. Non-transactional and standalone-compatible: a single mongod (no replica
 # set) is sufficient. See docs/storage/mongodb.md
 #  - name: mongo-01
-#    driver: mongo
 #    affinity: 1
-#
-#    config:
+#    mongo:
 #      connection-string: "mongodb://user:pass@localhost:27017"
 #      database: querator
 #      # Caps the driver connection pool per client; omit for the driver default.
-#      max-pool-size: "50"
+#      max-pool-size: 50
 
 # MongoDB may also back queue metadata. When queue and partition storage share a connection string
 # they share one driver client, so set max-pool-size consistently in both places.
 # queue-storage:
-#   driver: mongo
-#   config:
+#   mongo:
 #     connection-string: "mongodb://user:pass@localhost:27017"
 #     database: querator
-#     max-pool-size: "50"
+#     max-pool-size: 50
 
 # Auth Backend defines the authentication and authorization backend.
 # Options:


### PR DESCRIPTION
### Purpose

Backend storage configuration was an untyped `map[string]string`. When the config was parsed, any key the driver didn't recognize was silently dropped — so a typo (`max-poolsize` instead of `max-pool-size`) or a misplaced key (`max-pool-size` under a `badger` block, where it means nothing) used the default with no error. The user got no feedback that their config did nothing, and it wasn't clear which option belonged to which backend.

This change makes backend ownership **structural** and turns silent drops into startup errors. Each storage entry now nests its options under a section named for the backend, and the config is decoded strictly.

Before:

```yaml
partition-storage:
  - name: mongo-01
    driver: mongo
    config:
      connection-string: "mongodb://user:pass@localhost:27017"
      max-pool-size: "50"
queue-storage:
  driver: badger
  config:
    storage-dir: /data/queues
```

After:

```yaml
partition-storage:
  - name: mongo-01
    affinity: 1
    mongo:
      connection-string: "mongodb://user:pass@localhost:27017"
      max-pool-size: 50
queue-storage:
  badger:
    storage-dir: /data/queues
```

All of the following are now reported as errors at startup instead of being silently ignored:

- a misspelled key (`max-poolsize`)
- an option placed under the wrong backend (`max-pool-size` under `badger`)
- a mistyped value (`max-pool-size: not-a-number`)
- a missing required value (`mongo` without `connection-string`)
- zero or multiple backends defined in a single storage entry

The in-memory backend has no options and is selected with `memory: {}`. Pool size is now a real integer rather than a quoted string.

### Implementation

- **`daemon/config.go`** — Replaced the `driver` string + `map[string]string` config on `PartitionStorage` and `QueueStorage` with optional typed backend sections (`*MemoryConfig`, `*BadgerConfig`, `*MongoConfig`). Each backend config carries its own `validate()` for required values. `setupPartitionStorage`/`setupQueueStorage` now select the backend via a shared `selected`/`backendErr` helper that enforces exactly one backend per entry (queue storage defaults to memory when none is set). Removed `parseMaxPoolSize` — `max-pool-size` is decoded directly as a typed `uint64`.
- Added `ReadConfig(io.Reader)`, which decodes the YAML with `yaml.KnownFields(true)`. This is what rejects unknown/misplaced keys and mistyped values; it is the single decode surface used by both the server and the tests.
- **`cmd/querator/server.go`** — Reads config through `daemon.ReadConfig` instead of a bare decoder.
- **`example.yaml`** and **`docs/storage/*.md`** — Rewritten to the nested format; `max-pool-size` shown as an unquoted integer.
- **`daemon/config_test.go`** — Tests go through the public surface (`ReadConfig` / `ApplyConfigFile`) from `package daemon_test`. Added `TestReadConfigErrs` (decode-time: misspelled, misplaced, mistyped, unknown top-level key), expanded `TestApplyConfigFileErrs` (semantic: missing required and zero/multiple backends, on both partition and queue paths), converted the existing YAML tests to the nested format, and added `TestExampleConfigDecodes` to guard the shipped `example.yaml` against the strict decoder.

Postgres wiring is intentionally out of scope and tracked separately by ENG-52.
