### PR TITLE
Wire PostgreSQL into daemon config (driver: postgres)

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -111,21 +111,23 @@ type Logging struct {
 }
 
 // QueueStorage selects the backend that stores queue metadata. Exactly one backend section
-// (memory, badger, or mongo) may be set. When none is set, the in-memory backend is used.
+// (memory, badger, mongo, or postgres) may be set. When none is set, the in-memory backend is used.
 type QueueStorage struct {
-	Memory *MemoryConfig `yaml:"memory"`
-	Badger *BadgerConfig `yaml:"badger"`
-	Mongo  *MongoConfig  `yaml:"mongo"`
+	Memory   *MemoryConfig   `yaml:"memory"`
+	Badger   *BadgerConfig   `yaml:"badger"`
+	Mongo    *MongoConfig    `yaml:"mongo"`
+	Postgres *PostgresConfig `yaml:"postgres"`
 }
 
 // PartitionStorage selects the backend for a named partition store. Exactly one backend section
-// (memory, badger, or mongo) must be set.
+// (memory, badger, mongo, or postgres) must be set.
 type PartitionStorage struct {
-	Name     string        `yaml:"name"`
-	Affinity int           `yaml:"affinity"`
-	Memory   *MemoryConfig `yaml:"memory"`
-	Badger   *BadgerConfig `yaml:"badger"`
-	Mongo    *MongoConfig  `yaml:"mongo"`
+	Name     string          `yaml:"name"`
+	Affinity int             `yaml:"affinity"`
+	Memory   *MemoryConfig   `yaml:"memory"`
+	Badger   *BadgerConfig   `yaml:"badger"`
+	Mongo    *MongoConfig    `yaml:"mongo"`
+	Postgres *PostgresConfig `yaml:"postgres"`
 }
 
 // MemoryConfig configures the in-memory backend. It accepts no options; select it with an empty
@@ -154,6 +156,20 @@ type MongoConfig struct {
 func (c MongoConfig) validate() error {
 	if c.ConnectionString == "" {
 		return errors.New("mongo: 'connection-string' is required")
+	}
+	return nil
+}
+
+// PostgresConfig configures the PostgreSQL backend.
+type PostgresConfig struct {
+	ConnectionString string `yaml:"connection-string"`
+	MaxConns         int32  `yaml:"max-conns"`
+	ScanBatchSize    int    `yaml:"scan-batch-size"`
+}
+
+func (c PostgresConfig) validate() error {
+	if c.ConnectionString == "" {
+		return errors.New("postgres: 'connection-string' is required")
 	}
 	return nil
 }
@@ -261,7 +277,7 @@ func toLogLevel(level string) slog.Level {
 
 // selected reports the name of the single backend that is set and how many are set, so callers can
 // enforce the "exactly one backend" rule with a clear error.
-func selected(memory, badger, mongo bool) (name string, count int) {
+func selected(memory, badger, mongo, postgres bool) (name string, count int) {
 	if memory {
 		name, count = "memory", count+1
 	}
@@ -271,19 +287,22 @@ func selected(memory, badger, mongo bool) (name string, count int) {
 	if mongo {
 		name, count = "mongo", count+1
 	}
+	if postgres {
+		name, count = "postgres", count+1
+	}
 	return name, count
 }
 
 func backendErr(what string, count int) error {
 	if count == 0 {
-		return fmt.Errorf("%s must define exactly one backend (memory, badger, mongo)", what)
+		return fmt.Errorf("%s must define exactly one backend (memory, badger, mongo, postgres)", what)
 	}
-	return fmt.Errorf("%s defines multiple backends; only one of (memory, badger, mongo) is allowed", what)
+	return fmt.Errorf("%s defines multiple backends; only one of (memory, badger, mongo, postgres) is allowed", what)
 }
 
 func setupPartitionStorage(file File, d *Config) error {
 	for _, ps := range file.PartitionStorage {
-		name, count := selected(ps.Memory != nil, ps.Badger != nil, ps.Mongo != nil)
+		name, count := selected(ps.Memory != nil, ps.Badger != nil, ps.Mongo != nil, ps.Postgres != nil)
 		if count != 1 {
 			return backendErr(fmt.Sprintf("partition storage '%s'", ps.Name), count)
 		}
@@ -310,6 +329,16 @@ func setupPartitionStorage(file File, d *Config) error {
 				MaxPoolSize:      ps.Mongo.MaxPoolSize,
 				Log:              d.Service.Log,
 			})
+		case "postgres":
+			if err := ps.Postgres.validate(); err != nil {
+				return err
+			}
+			s = store.NewPostgresPartitionStore(store.PostgresConfig{
+				ConnectionString: ps.Postgres.ConnectionString,
+				MaxConns:         ps.Postgres.MaxConns,
+				ScanBatchSize:    ps.Postgres.ScanBatchSize,
+				Log:              d.Service.Log,
+			})
 		default:
 			return fmt.Errorf("unknown backend %q", name)
 		}
@@ -325,7 +354,7 @@ func setupPartitionStorage(file File, d *Config) error {
 
 func setupQueueStorage(ctx context.Context, file File, conf *Config) error {
 	qs := file.QueueStorage
-	name, count := selected(qs.Memory != nil, qs.Badger != nil, qs.Mongo != nil)
+	name, count := selected(qs.Memory != nil, qs.Badger != nil, qs.Mongo != nil, qs.Postgres != nil)
 	if count > 1 {
 		return backendErr("queue storage", count)
 	}
@@ -349,6 +378,16 @@ func setupQueueStorage(ctx context.Context, file File, conf *Config) error {
 			ConnectionString: qs.Mongo.ConnectionString,
 			Database:         qs.Mongo.Database,
 			MaxPoolSize:      qs.Mongo.MaxPoolSize,
+			Log:              conf.Service.Log,
+		})
+	case "postgres":
+		if err := qs.Postgres.validate(); err != nil {
+			return err
+		}
+		conf.Service.StorageConfig.Queues = store.NewPostgresQueues(store.PostgresConfig{
+			ConnectionString: qs.Postgres.ConnectionString,
+			MaxConns:         qs.Postgres.MaxConns,
+			ScanBatchSize:    qs.Postgres.ScanBatchSize,
 			Log:              conf.Service.Log,
 		})
 	default:

--- a/daemon/config_test.go
+++ b/daemon/config_test.go
@@ -105,7 +105,7 @@ func TestApplyConfigFileErrs(t *testing.T) {
 					{Name: "test"},
 				},
 			},
-			expectedErr: "partition storage 'test' must define exactly one backend (memory, badger, mongo)",
+			expectedErr: "partition storage 'test' must define exactly one backend (memory, badger, mongo, postgres)",
 		},
 		{
 			name: "PartitionStorageMultipleBackends",
@@ -118,7 +118,7 @@ func TestApplyConfigFileErrs(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "partition storage 'test' defines multiple backends; only one of (memory, badger, mongo) is allowed",
+			expectedErr: "partition storage 'test' defines multiple backends; only one of (memory, badger, mongo, postgres) is allowed",
 		},
 		{
 			name: "PartitionStorageMongoMissingConnectionString",
@@ -131,6 +131,18 @@ func TestApplyConfigFileErrs(t *testing.T) {
 				},
 			},
 			expectedErr: "mongo: 'connection-string' is required",
+		},
+		{
+			name: "PartitionStoragePostgresMissingConnectionString",
+			file: daemon.File{
+				PartitionStorage: []daemon.PartitionStorage{
+					{
+						Name:     "postgres-00",
+						Postgres: &daemon.PostgresConfig{MaxConns: 10},
+					},
+				},
+			},
+			expectedErr: "postgres: 'connection-string' is required",
 		},
 		{
 			name: "PartitionStorageBadgerMissingStorageDir",
@@ -152,7 +164,7 @@ func TestApplyConfigFileErrs(t *testing.T) {
 					Mongo:  &daemon.MongoConfig{ConnectionString: "mongodb://localhost:27017"},
 				},
 			},
-			expectedErr: "queue storage defines multiple backends; only one of (memory, badger, mongo) is allowed",
+			expectedErr: "queue storage defines multiple backends; only one of (memory, badger, mongo, postgres) is allowed",
 		},
 		{
 			name: "QueueStorageMongoMissingConnectionString",
@@ -162,6 +174,15 @@ func TestApplyConfigFileErrs(t *testing.T) {
 				},
 			},
 			expectedErr: "mongo: 'connection-string' is required",
+		},
+		{
+			name: "QueueStoragePostgresMissingConnectionString",
+			file: daemon.File{
+				QueueStorage: daemon.QueueStorage{
+					Postgres: &daemon.PostgresConfig{MaxConns: 10},
+				},
+			},
+			expectedErr: "postgres: 'connection-string' is required",
 		},
 		{
 			name: "QueueStorageBadgerMissingStorageDir",
@@ -374,4 +395,41 @@ queue-storage:
 	// a process-global client keyed by connection string, so an unset size here would override the
 	// partition-storage pool cap depending on which storage acquires the client first.
 	assert.Equal(t, uint64(25), queueConfig.MaxPoolSize)
+}
+
+func TestPostgresConfig(t *testing.T) {
+	postgresConfig := `
+partition-storage:
+  - name: postgres-00
+    affinity: 1
+    postgres:
+      connection-string: "postgres://localhost:5432/querator"
+      max-conns: 50
+      scan-batch-size: 500
+queue-storage:
+  postgres:
+    connection-string: "postgres://localhost:5432/querator"
+    max-conns: 25
+    scan-batch-size: 250
+`
+	file, err := daemon.ReadConfig(strings.NewReader(postgresConfig))
+	require.NoError(t, err)
+
+	var conf daemon.Config
+	ctx := context.Background()
+	err = daemon.ApplyConfigFile(ctx, &conf, file, io.Discard)
+	require.NoError(t, err)
+
+	partitionConfig := conf.Service.StorageConfig.PartitionStorage[0].PartitionStore.(*store.PostgresPartitionStore).Config()
+	assert.Equal(t, "postgres://localhost:5432/querator", partitionConfig.ConnectionString)
+	assert.Equal(t, int32(50), partitionConfig.MaxConns)
+	assert.Equal(t, 500, partitionConfig.ScanBatchSize)
+
+	queueConfig := conf.Service.StorageConfig.Queues.(*store.PostgresQueues).Config()
+	assert.Equal(t, "postgres://localhost:5432/querator", queueConfig.ConnectionString)
+	// queue-storage must honor max-conns, not silently drop it: queue and partition storage share a
+	// process-global pgx pool keyed by connection string, so the first storage to acquire the pool
+	// sets the cap. An unset value here would let one path override the other's pool size.
+	assert.Equal(t, int32(25), queueConfig.MaxConns)
+	assert.Equal(t, 250, queueConfig.ScanBatchSize)
 }

--- a/example.yaml
+++ b/example.yaml
@@ -31,17 +31,15 @@ partition-storage:
   #    affinity: 1
   #    memory: {}
 
+# PostgreSQL partition storage.
 #  - name: postgres-01
 #    affinity: 1
 #    postgres:
-#      host: localhost
-#      port: 5432
-#      user: foo
-#      pass: bar
-#      database: querator
-#      ca-file: /path/to/ca
-#      client-cert: /path/to/client/cert
-#      client-key: /path/to/client/key
+#      connection-string: "postgres://user:pass@localhost:5432/querator"
+#      # Caps the pgx connection pool per client; omit for the driver default.
+#      max-conns: 50
+#      # Rows fetched per scan batch; omit to use the default (1000).
+#      scan-batch-size: 1000
 
 # MongoDB partition storage. Non-transactional and standalone-compatible: a single mongod (no replica
 # set) is sufficient. See docs/storage/mongodb.md
@@ -60,6 +58,14 @@ partition-storage:
 #     connection-string: "mongodb://user:pass@localhost:27017"
 #     database: querator
 #     max-pool-size: 50
+
+# PostgreSQL may also back queue metadata. When queue and partition storage share a connection string
+# they share one pgx pool, so set max-conns consistently in both places.
+# queue-storage:
+#   postgres:
+#     connection-string: "postgres://user:pass@localhost:5432/querator"
+#     max-conns: 50
+#     scan-batch-size: 1000
 
 # Auth Backend defines the authentication and authorization backend.
 # Options:

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -179,6 +179,10 @@ func NewPostgresQueues(conf PostgresConfig) *PostgresQueues {
 	return &PostgresQueues{conf: conf}
 }
 
+func (p *PostgresQueues) Config() PostgresConfig {
+	return p.conf
+}
+
 func (p *PostgresQueues) ensureTable(_ context.Context, pool *pgxpool.Pool) error {
 	// Use a context with reasonable timeout for table creation
 	bgCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -476,6 +480,10 @@ func NewPostgresPartitionStore(conf PostgresConfig) *PostgresPartitionStore {
 	set.Default(&conf.Log, slog.Default())
 	set.Default(&conf.ScanBatchSize, 1000)
 	return &PostgresPartitionStore{conf: conf}
+}
+
+func (p *PostgresPartitionStore) Config() PostgresConfig {
+	return p.conf
 }
 
 func (p *PostgresPartitionStore) Get(info types.PartitionInfo) Partition {


### PR DESCRIPTION
### Purpose
PostgreSQL has a full storage backend (`internal/store/postgres.go`) and is exercised in the test suite, but it had **no daemon wiring** — `daemon/config.go` only knew `memory`, `badger`, and `mongo`. Operators could not deploy the Postgres backend through YAML config. This adds a typed `postgres` backend section so it can be selected for both partition and queue storage.

Operators can now configure Postgres in `config.yaml`:

```yaml
partition-storage:
  - name: postgres-00
    affinity: 1
    postgres:
      connection-string: "postgres://user:pass@localhost:5432/querator"
      max-conns: 50
      scan-batch-size: 1000

# Postgres may also back queue metadata. When queue and partition storage share a
# connection string they share one pgx pool, so set max-conns consistently.
queue-storage:
  postgres:
    connection-string: "postgres://user:pass@localhost:5432/querator"
    max-conns: 50
    scan-batch-size: 1000
```

A missing `connection-string` is rejected at startup with `postgres: 'connection-string' is required`.

### Implementation
- Added a typed `PostgresConfig` YAML section (`connection-string`, `max-conns`, `scan-batch-size`) to both `QueueStorage` and `PartitionStorage`, with `validate()` requiring the connection string — mirroring the existing `mongo` wiring.
- Added `case "postgres":` to `setupPartitionStorage` and `setupQueueStorage`, constructing `store.PostgresConfig`.
- Extended `selected()` and the "exactly one backend" error strings to include `postgres`.
- Added `Config()` accessors to `PostgresQueues` and `PostgresPartitionStore` (Postgres lacked the accessors Mongo/Badger already had; the config tests assert through them).
- Added `TestPostgresConfig` plus partition/queue missing-connection-string error cases; updated the three existing error-string expectations.
- Replaced the stale `postgres` stub in `example.yaml` (it used nonexistent host/port/user/pass fields) with the real fields and a queue-storage example.

Fixes ENG-52