### PR TITLE
Fix handleStats per-partition mis-attribution (ENG-56)

### DIFF
--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -80,14 +80,20 @@ func (l *Logical) handleStats(state *QueueState, r *Request) {
 		if err := p.Stats(r.Context, &ps, now); err != nil {
 			r.Err = err
 		}
-		s := state.Partitions[p.Info().PartitionNum]
+		ps.Partition = p.Info().PartitionNum
+		// Look up the in-memory partition by number. state.Partitions is
+		// continuously reordered by sortPartitionsByLoad (ADR-0019), so it
+		// cannot be indexed by partition number.
+		s := state.GetPartition(p.Info().PartitionNum)
 		// TODO Override the on disk stats with in-memory stats. We should
 		//  warn if these stats do not match, or avoid querying the disk, or
 		//  make fetching on disk stats a separate call.
-		ps.Failures = s.State.Failures
-		ps.NumLeased = s.State.NumLeased
-		ps.UnLeased = s.State.UnLeased
-		ps.NextLifecycleRun = s.Lifecycle.NextLifecycleRun.Sub(now)
+		if s != nil {
+			ps.Failures = s.State.Failures
+			ps.NumLeased = s.State.NumLeased
+			ps.UnLeased = s.State.UnLeased
+			ps.NextLifecycleRun = s.Lifecycle.NextLifecycleRun.Sub(now)
+		}
 		qs.Partitions = append(qs.Partitions, ps)
 	}
 

--- a/service/partition_test.go
+++ b/service/partition_test.go
@@ -161,6 +161,54 @@ func testPartitions(t *testing.T, setup NewStorageFunc, tearDown func()) {
 		assert.Equal(t, 1, notLeased)
 	})
 
+	// Regression for ENG-56: QueueStats must report each partition's own
+	// number and in-memory state. Producing more items to partition 0 than
+	// partition 1 forces sortPartitionsByLoad (ADR-0019) to reorder the
+	// in-memory partition slice away from partition-number order.
+	t.Run("StatsPerPartitionInMemory", func(t *testing.T) {
+		var queueName = random.String("queue-", 10)
+
+		createQueueAndWait(t, ctx, c, &pb.QueueInfo{
+			QueueName:           queueName,
+			LeaseTimeout:        "1m",
+			ExpireTimeout:       "10m",
+			MaxAttempts:         10,
+			RequestedPartitions: 2,
+		})
+
+		// First batch lands in partition 0, second batch in partition 1. The
+		// larger first batch makes partition 0 the heavier partition, so the
+		// load sort reorders state.Partitions away from partition-number order.
+		require.NoError(t, c.QueueProduce(ctx, &pb.QueueProduceRequest{
+			Items:          produceRandomItems(11),
+			QueueName:      queueName,
+			RequestTimeout: "1m",
+		}))
+		require.NoError(t, c.QueueProduce(ctx, &pb.QueueProduceRequest{
+			Items:          produceRandomItems(10),
+			QueueName:      queueName,
+			RequestTimeout: "1m",
+		}))
+
+		var stats pb.QueueStatsResponse
+		require.NoError(t, c.QueueStats(ctx, &pb.QueueStatsRequest{QueueName: queueName}, &stats))
+		require.Len(t, stats.LogicalQueues, 1)
+		require.Len(t, stats.LogicalQueues[0].Partitions, 2)
+
+		// The Partitions slice is ordered by partition number. No items are
+		// leased, so each partition's in-memory UnLeased must equal its
+		// storage-derived Total, and each entry must carry its own number.
+		partition0 := stats.LogicalQueues[0].Partitions[0]
+		assert.Equal(t, int32(0), partition0.Partition)
+		assert.Equal(t, int32(11), partition0.Total)
+		assert.Equal(t, int32(11), partition0.UnLeased)
+
+		partition1 := stats.LogicalQueues[0].Partitions[1]
+		assert.Equal(t, int32(1), partition1.Partition)
+		assert.Equal(t, int32(10), partition1.Total)
+		assert.Equal(t, int32(10), partition1.UnLeased)
+	})
+
 	t.Run("OpportunisticLease", func(t *testing.T) {
 		var queueName = random.String("queue-", 10)
 


### PR DESCRIPTION
### Purpose
`QueueStats` reported per-partition numbers that were silently wrong for any queue with more than one partition. Two distinct bugs in `handleStats` caused it:

1. **In-memory state attributed to the wrong partition.** `handleStats` overrode storage-derived stats with in-memory state by indexing `state.Partitions[p.Info().PartitionNum]`. But `state.Partitions` is continuously reordered by `sortPartitionsByLoad` (opportunistic distribution, ADR-0019), so once a queue had two partitions at different loads, the slice offset no longer matched the partition number. `Failures`, `NumLeased`, `UnLeased`, and `NextLifecycleRun` were attributed to the wrong partition.
2. **Partition number never set.** `ps.Partition` was never assigned (no storage backend sets it either), so every partition entry in the response reported `Partition: 0`.

Totals were unaffected by the first bug; only the per-partition in-memory fields were wrong. Single-partition queues were unaffected (slice index equals partition number), which is why existing single-partition stats tests never caught it.

After this change, a multi-partition `QueueStats` call reports each partition's own number and in-memory counts:

```go
var stats pb.QueueStatsResponse
require.NoError(t, c.QueueStats(ctx, &pb.QueueStatsRequest{QueueName: name}, &stats))

p0 := stats.LogicalQueues[0].Partitions[0]  // Partition: 0, UnLeased matches its own Total
p1 := stats.LogicalQueues[0].Partitions[1]  // Partition: 1, UnLeased matches its own Total
```

### Implementation
- **`internal/handlers.go`** — `handleStats` now looks the in-memory partition up by number via `state.GetPartition(p.Info().PartitionNum)` instead of indexing the load-sorted slice, guarded for a nil result. Also sets `ps.Partition = p.Info().PartitionNum` so each entry carries its own number.
- **`service/partition_test.go`** — adds the `StatsPerPartitionInMemory` surface test. It produces a larger first batch (11 items → partition 0) than second (10 → partition 1) to force `sortPartitionsByLoad` to reorder the in-memory slice away from partition-number order, then asserts each partition reports its own number and that in-memory `UnLeased` matches the storage-derived `Total`. Runs against every storage backend. Verified failing on the pre-fix code (in-memory counts swapped; partition number always 0) and passing after.

Fixes ENG-56