### PR TITLE
Constrain dead-letter queues to a single partition (ENG-57)

### DIFF
--- a/internal/queues_manager.go
+++ b/internal/queues_manager.go
@@ -379,6 +379,15 @@ func (qm *QueuesManager) validateDeadQueue(ctx context.Context, info types.Queue
 		return reply.NewInvalidOption("dead_queue is invalid; '%s' already has its own dead_queue configured", info.DeadQueue)
 	}
 
+	// Enforce single-partition dead-letter queues (ENG-57). SourceID dedup is partition-scoped,
+	// so a multi-partition DLQ can duplicate an item when a failed-then-retried lifecycle move
+	// lands on a different partition than the first attempt and escapes the partition-local
+	// SourceID index. Constraining the DLQ to one partition makes that dedup a hard guarantee.
+	if dlqInfo.RequestedPartitions > 1 {
+		return reply.NewInvalidOption("dead_queue is invalid; '%s' must have a single partition, but has '%d'",
+			info.DeadQueue, dlqInfo.RequestedPartitions)
+	}
+
 	return nil
 }
 

--- a/service/queues_test.go
+++ b/service/queues_test.go
@@ -390,6 +390,64 @@ func testQueues(t *testing.T, setup NewStorageFunc, tearDown func()) {
 					assert.Contains(t, duhErr.Message(), "already has its own dead_queue configured")
 				})
 
+				t.Run("MultiPartitionDLQ", func(t *testing.T) {
+					dlqName := random.String("dlq-", 10)
+					queueName := random.String("queue-", 10)
+
+					// Create a DLQ with multiple partitions. SourceID dedup is partition-scoped,
+					// so a multi-partition DLQ cannot guarantee no duplicates on a retried move (ENG-57).
+					require.NoError(t, c.QueuesCreate(ctx, &pb.QueueInfo{
+						QueueName:           dlqName,
+						ExpireTimeout:       "10m",
+						LeaseTimeout:        "1m",
+						RequestedPartitions: 2,
+					}))
+
+					// Creating a source queue that references the multi-partition DLQ must be rejected
+					err := c.QueuesCreate(ctx, &pb.QueueInfo{
+						QueueName:           queueName,
+						DeadQueue:           dlqName,
+						ExpireTimeout:       "10m",
+						LeaseTimeout:        "1m",
+						RequestedPartitions: 1,
+					})
+					require.Error(t, err)
+					var duhErr duh.Error
+					require.True(t, errors.As(err, &duhErr))
+					assert.Equal(t, duh.CodeBadRequest, duhErr.Code())
+					assert.Contains(t, duhErr.Message(), "must have a single partition")
+				})
+
+				t.Run("MultiPartitionDLQOnUpdate", func(t *testing.T) {
+					dlqName := random.String("dlq-", 10)
+					queueName := random.String("queue-", 10)
+
+					require.NoError(t, c.QueuesCreate(ctx, &pb.QueueInfo{
+						QueueName:           dlqName,
+						ExpireTimeout:       "10m",
+						LeaseTimeout:        "1m",
+						RequestedPartitions: 2,
+					}))
+
+					// Create a source queue with no DLQ, then attempt to add the multi-partition DLQ via update
+					require.NoError(t, c.QueuesCreate(ctx, &pb.QueueInfo{
+						QueueName:           queueName,
+						ExpireTimeout:       "10m",
+						LeaseTimeout:        "1m",
+						RequestedPartitions: 1,
+					}))
+
+					err := c.QueuesUpdate(ctx, &pb.QueueInfo{
+						QueueName: queueName,
+						DeadQueue: dlqName,
+					})
+					require.Error(t, err)
+					var duhErr duh.Error
+					require.True(t, errors.As(err, &duhErr))
+					assert.Equal(t, duh.CodeBadRequest, duhErr.Code())
+					assert.Contains(t, duhErr.Message(), "must have a single partition")
+				})
+
 				t.Run("ValidDLQ", func(t *testing.T) {
 					dlqName := random.String("dlq-", 10)
 					queueName := random.String("queue-", 10)

--- a/service/queues_test.go
+++ b/service/queues_test.go
@@ -478,6 +478,38 @@ func testQueues(t *testing.T, setup NewStorageFunc, tearDown func()) {
 					require.Equal(t, 1, len(list.Items))
 					assert.Equal(t, dlqName, list.Items[0].DeadQueue)
 				})
+
+				t.Run("MultiPartitionSourceQueue", func(t *testing.T) {
+					dlqName := random.String("dlq-", 10)
+					queueName := random.String("queue-", 10)
+
+					// Single-partition DLQ
+					require.NoError(t, c.QueuesCreate(ctx, &pb.QueueInfo{
+						QueueName:           dlqName,
+						ExpireTimeout:       "10m",
+						LeaseTimeout:        "1m",
+						RequestedPartitions: 1,
+					}))
+
+					// The single-partition constraint applies only to the DLQ. A source queue with
+					// multiple partitions referencing a single-partition DLQ is valid (ENG-57).
+					require.NoError(t, c.QueuesCreate(ctx, &pb.QueueInfo{
+						QueueName:           queueName,
+						DeadQueue:           dlqName,
+						ExpireTimeout:       "10m",
+						LeaseTimeout:        "1m",
+						RequestedPartitions: 8,
+					}))
+
+					var list pb.QueuesListResponse
+					require.NoError(t, c.QueuesList(ctx, &list, &querator.ListOptions{
+						Pivot: queueName,
+						Limit: 1,
+					}))
+					require.Equal(t, 1, len(list.Items))
+					assert.Equal(t, dlqName, list.Items[0].DeadQueue)
+					assert.Equal(t, int32(8), list.Items[0].RequestedPartitions)
+				})
 			})
 		})
 


### PR DESCRIPTION
### Purpose
Dead-letter `SourceID` dedup is partition-scoped — each partition's storage keeps its own `SourceID` index. After ENG-55 routed dead-letter production through the dead-letter queue's `requestLoop`, internal produce now distributes opportunistically across partitions (ADR-0019). The consequence: a failed-then-retried lifecycle move can land on a *different* dead-letter partition than the first attempt, escape the partition-local `SourceID` index, and produce a duplicate. For a multi-partition dead-letter queue, duplicates are possible by construction.

This change closes that window by making a multi-partition dead-letter queue unconfigurable. Any queue that references a dead-letter queue with more than one partition is now rejected at config time:

    # DLQ with 2 partitions
    QueuesCreate({QueueName: "dlq", RequestedPartitions: 2})

    # Referencing it is now rejected:
    QueuesCreate({QueueName: "orders", DeadQueue: "dlq", RequestedPartitions: 1})
    # => CodeBadRequest: dead_queue is invalid; 'dlq' must have a single partition, but has '2'

With a single partition, every dead-letter produce lands on the same partition, so the partition-local dedup becomes a hard guarantee. Dead-letter queues are low-volume inspect/replay queues, so the single-partition constraint is a reasonable contract.

### Implementation
- `internal/queues_manager.go` — `validateDeadQueue` now rejects a referenced dead-letter queue whose `RequestedPartitions > 1`. Because both `Create` and `Update` of a source queue run `validateDeadQueue`, the contract is enforced on both paths.
- `service/queues_test.go` — two surface tests under `DeadLetterQueue/Validation`: `MultiPartitionDLQ` (create-path rejection) and `MultiPartitionDLQOnUpdate` (update-path rejection). Both run across all four backends (InMemory, BadgerDB, PostgreSQL, MongoDB).

Fixes ENG-57